### PR TITLE
Fix issue 9 and other minor improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The delegation contract is used by delegators to stake and unstake ZIL with the 
 
 `LiquidDelegation` is the initial implementation of the liquid staking variant of the delegation contract that creates a `NonRebasingLST` contract when it is initialized. `LiquidDelegationV2` implements all other features. `NonLiquidDelegation` is the initial implementation of the non-liquid staking variant of the delegation contract that allows delegators to withdraw rewards.
 
-The delegation contract shall be deployed and upgraded by the account with the private key that was used to run the validator node and was used to generate its BLS keypair and peer id. Make sure the `PRIVATE_KEY` environment variable is set accordingly.
+Before running the deployment script, set the `PRIVATE_KEY` environment variable to the private key of the contract owner. Note that only the contract owner will be able to upgrade the contract, change the commission and activate the node as a validator.
 
 To deploy `LiquidDelegation` run
 ```bash
@@ -60,7 +60,7 @@ The output will look like this:
 
 Now or at a later time you can set the commission on the rewards the validator earns to e.g. 10% as follows:
 ```bash
-forge script script/commission_Delegation.s.sol --rpc-url http://localhost:4201 --broadcast --legacy --sig "run(address payable, uint16, bool)" 0x7A0b7e6D24eDe78260c9ddBD98e828B0e11A8EA2 1000 false
+forge script script/commission_Delegation.s.sol --rpc-url http://localhost:4201 --broadcast --legacy --sig "run(address payable, string, bool)" 0x7A0b7e6D24eDe78260c9ddBD98e828B0e11A8EA2 1000 false
 ```
 
 The output will contain the following information:
@@ -77,7 +77,7 @@ cast call 0x7A0b7e6D24eDe78260c9ddBD98e828B0e11A8EA2 "DENOMINATOR()(uint256)" --
 
 Once the validator is activated and starts earning rewards, commissions are transferred automatically to the validator node's account. Commissions of a non-liquid staking validator are deducted when delegators withdraw rewards. In case of the liquid staking variant, commissions are deducted each time delegators stake, unstake or claim what they unstaked, or when the node requests the outstanding commissions that haven't been transferred yet. To collect them, run
 ```bash
-forge script script/commission_Delegation.s.sol --rpc-url http://localhost:4201 --broadcast --legacy --sig "run(address payable, string, bool)" 0x7A0b7e6D24eDe78260c9ddBD98e828B0e11A8EA2 10001 true
+forge script script/commission_Delegation.s.sol --rpc-url http://localhost:4201 --broadcast --legacy --sig "run(address payable, string, bool)" 0x7A0b7e6D24eDe78260c9ddBD98e828B0e11A8EA2 same true
 ```
 using `same` for the second argument to leave the commission percentage unchanged and `true` for the third argument. Replacing the second argument with `same` and the third argument with `false` only displays the current commission rate.
 

--- a/src/Deposit.sol
+++ b/src/Deposit.sol
@@ -158,10 +158,10 @@ contract Deposit {
     // or withdrawals were made.
     uint64 latestComputedEpoch;
 
-    uint256 public minimumStake;
-    uint256 public maximumStakers;
+    uint256 public immutable minimumStake;
+    uint256 public immutable maximumStakers;
 
-    uint64 public blocksPerEpoch;
+    uint64 public immutable blocksPerEpoch;
 
     modifier onlyControlAddress(bytes calldata blsPubKey) {
         require(blsPubKey.length == 48);
@@ -314,6 +314,22 @@ contract Deposit {
         return committee().stakers[blsPubKey].balance;
     }
 
+    function getFutureStake(
+        bytes calldata blsPubKey
+    ) public view returns (uint256) {
+        require(blsPubKey.length == 48);
+
+        // if `latestComputedEpoch > currentEpoch()`
+        // then `latestComputedEpoch` determines the future committee we need
+        // otherwise there are no committee changes after `currentEpoch()`
+        // i.e. `latestComputedEpoch` determines the most recent committee
+        Committee storage latestCommittee = _committee[latestComputedEpoch % 3];
+
+        // We don't need to check if `blsPubKey` is in `stakerKeys` here. If the `blsPubKey` is not a staker, the
+        // balance will default to zero.
+        return latestCommittee.stakers[blsPubKey].balance;
+    }
+
     function getRewardAddress(
         bytes calldata blsPubKey
     ) public view returns (address) {
@@ -415,7 +431,7 @@ contract Deposit {
             signature,
             pubkey
         );
-        // mocked to make the tests work
+        //TODO: don't remove the next line
         return true;
         uint inputLength = input.length;
         bytes memory output = new bytes(32);
@@ -515,7 +531,7 @@ contract Deposit {
             futureCommittee.stakers[stakerKey].index != 0,
             "staker does not exist"
         );
-        //TODO: why is this required? to prevent unstaking from initialStakers?
+        //TODO: keep the next line commented out
         //require(futureCommittee.stakerKeys.length > 1, "too few stakers");
         require(
             futureCommittee.stakers[stakerKey].balance >= amount,
@@ -586,12 +602,10 @@ contract Deposit {
         _withdraw(count);
     }
 
-    function withdrawalPeriod() public pure returns (uint256) {
-        // 2 weeks
-        //return 2 * 7 * 24 * 60 * 60;
-        //TODO: return 14 days;
-        // modified to 30 seconds to make the tests faster
-        return 30;
+    function withdrawalPeriod() public view returns (uint256) {
+        // shorter unbonding period for testing deposit withdrawals
+        if (block.chainid == 33469) return 5 minutes;
+        return 2 weeks;
     }
 
     function _withdraw(uint256 count) internal {
@@ -621,265 +635,3 @@ contract Deposit {
         require(sent, "failed to send");
     }
 }
-
-/* the code below based on an outdated version of deposit.sol
-struct Staker {
-    // The index of this staker's `blsPubKey` in the `_stakerKeys` array, plus 1. 0 is used for non-existing entries.
-    uint256 keyIndex;
-    // Invariant: `balance >= minimumStake`
-    uint256 balance;
-    address rewardAddress;
-    bytes peerId;
-}
-
-contract Deposit {
-    bytes[] _stakerKeys;
-    mapping(bytes => Staker) _stakersMap;
-    uint256 public totalStake;
-
-    uint256 public _minimumStake;
-    uint256 public _maximumStakers;
-
-    constructor(uint256 minimumStake, uint256 maximumStakers) {
-        _minimumStake = minimumStake;
-        _maximumStakers = maximumStakers;
-    }
-
-    function leaderFromRandomness(
-        uint256 randomness
-    ) private view returns (bytes memory) {
-        // Get a random number in the inclusive range of 0 to (totalStake - 1)
-        uint256 position = randomness % totalStake;
-        uint256 cummulative_stake = 0;
-
-        for (uint256 i = 0; i < _stakerKeys.length; i++) {
-            bytes storage stakerKey = _stakerKeys[i];
-            Staker storage staker = _stakersMap[stakerKey];
-
-            cummulative_stake += staker.balance;
-
-            if (position < cummulative_stake) {
-                return stakerKey;
-            }
-        }
-
-        revert("Unable to select next leader");
-    }
-
-    function leader() public view returns (bytes memory) {
-        return leaderFromRandomness(uint256(block.prevrandao));
-    }
-
-    function leaderAtView(
-        uint256 viewNumber
-    ) public view returns (bytes memory) {
-        uint256 randomness = uint256(
-            keccak256(bytes.concat(bytes32(viewNumber)))
-        );
-        return leaderFromRandomness(randomness);
-    }
-
-    // Temporary function to manually remove a staker. Can be called by the reward address of any staker with more than
-    // 10% stake. Will be removed later in development.
-    function tempRemoveStaker(bytes calldata blsPubKey) public {
-        require(blsPubKey.length == 48);
-
-        // Inefficient, but its fine because this is temporary.
-        for (uint256 i = 0; i < _stakerKeys.length; i++) {
-            bytes storage stakerKey = _stakerKeys[i];
-            Staker storage staker = _stakersMap[stakerKey];
-
-            // Check if the call is authorised.
-            if (
-                msg.sender == staker.rewardAddress &&
-                staker.balance > (totalStake / 10)
-            ) {
-                // The call is authorised, so we can delete the specified staker.
-                Staker storage stakerToDelete = _stakersMap[blsPubKey];
-
-                // Delete this staker's key from `_stakerKeys`. Swap the last element in the array into the deleted position.
-                bytes storage swappedStakerKey = _stakerKeys[
-                    _stakerKeys.length - 1
-                ];
-                Staker storage swappedStaker = _stakersMap[swappedStakerKey];
-                _stakerKeys[stakerToDelete.keyIndex - 1] = swappedStakerKey;
-                swappedStaker.keyIndex = stakerToDelete.keyIndex;
-
-                // The last element is now the element we want to delete.
-                _stakerKeys.pop();
-
-                // Reduce the total stake, but don't refund to the removed staker
-                totalStake -= stakerToDelete.balance;
-
-                // Delete the staker from `_stakersMap` too.
-                delete _stakersMap[blsPubKey];
-
-                return;
-            }
-        }
-        revert(
-            "call must come from a reward address corresponding to a staker with more than 10% stake"
-        );
-    }
-
-    // keep in-sync with zilliqa/src/precompiles.rs
-    function _popVerify(
-        bytes memory pubkey,
-        bytes memory signature
-    ) private view returns (bool) {
-        bytes memory input = abi.encodeWithSelector(
-            hex"bfd24965", // bytes4(keccak256("popVerify(bytes,bytes)"))
-            signature,
-            pubkey
-        );
-        // mocked to make the tests work
-        return true;
-        uint inputLength = input.length;
-        bytes memory output = new bytes(32);
-        bool success;
-        assembly {
-            success := staticcall(
-                gas(),
-                0x5a494c80, // "ZIL\x80"
-                add(input, 0x20),
-                inputLength,
-                add(output, 0x20),
-                32
-            )
-        }
-        require(success, "popVerify");
-        bool result = abi.decode(output, (bool));
-        return result;
-    }
-
-    function deposit(
-        bytes calldata blsPubKey,
-        bytes calldata peerId,
-        bytes calldata signature,
-        address rewardAddress
-    ) public payable {
-        require(blsPubKey.length == 48);
-        require(peerId.length == 38);
-        require(signature.length == 96);
-
-        require(_stakerKeys.length < _maximumStakers, "too many stakers");
-
-        // Verify signature as a proof-of-possession of the private key.
-        bool pop = _popVerify(blsPubKey, signature);
-        require(pop, "rogue key check");
-
-        uint256 keyIndex = _stakersMap[blsPubKey].keyIndex;
-        if (keyIndex == 0) {
-            // The staker will be at index `_stakerKeys.length`. We also need to add 1 to avoid the 0 sentinel value.
-            _stakersMap[blsPubKey].keyIndex = _stakerKeys.length + 1;
-            _stakerKeys.push(blsPubKey);
-        }
-
-        _stakersMap[blsPubKey].balance += msg.value;
-        totalStake += msg.value;
-
-        if (_stakersMap[blsPubKey].balance < _minimumStake) {
-            revert("stake less than minimum stake");
-        }
-
-        _stakersMap[blsPubKey].rewardAddress = rewardAddress;
-        _stakersMap[blsPubKey].peerId = peerId;
-    }
-
-    // temporary function to test liquid staking
-    function tempIncreaseDeposit(bytes calldata blsPubKey) public payable {
-        Staker storage staker = _stakersMap[blsPubKey];
-        require(staker.keyIndex != 0, "unknown staker");
-        require(staker.rewardAddress == msg.sender, "invalid sender");
-        staker.balance += msg.value;
-        totalStake += msg.value;
-    }
-
-    // temporary function to test liquid staking
-    function tempDecreaseDeposit(
-        bytes calldata blsPubKey,
-        uint256 amount
-    ) public {
-        Staker storage staker = _stakersMap[blsPubKey];
-        require(staker.keyIndex != 0, "unknown staker");
-        require(staker.rewardAddress == msg.sender, "invalid sender");
-        staker.balance -= amount;
-        require(
-            staker.balance == 0 || staker.balance >= _minimumStake,
-            "stake too low"
-        );
-        totalStake -= amount;
-        (bool success, ) = msg.sender.call{value: amount}("");
-        require(success, "withdrawal failed");
-    }
-
-    function setStake(
-        bytes calldata blsPubKey,
-        bytes calldata peerId,
-        address rewardAddress,
-        uint256 amount
-    ) public {
-        require(msg.sender == address(0));
-        require(blsPubKey.length == 48);
-        require(peerId.length == 38);
-
-        if (amount < _minimumStake) {
-            revert("stake less than minimum stake");
-        }
-
-        totalStake -= _stakersMap[blsPubKey].balance;
-        _stakersMap[blsPubKey].balance = amount;
-        totalStake += amount;
-        _stakersMap[blsPubKey].rewardAddress = rewardAddress;
-        _stakersMap[blsPubKey].peerId = peerId;
-        uint256 keyIndex = _stakersMap[blsPubKey].keyIndex;
-        if (keyIndex == 0) {
-            // The staker will be at index `_stakerKeys.length`. We also need to add 1 to avoid the 0 sentinel value.
-            _stakersMap[blsPubKey].keyIndex = _stakerKeys.length + 1;
-            _stakerKeys.push(blsPubKey);
-        }
-    }
-
-    function getStake(bytes calldata blsPubKey) public view returns (uint256) {
-        require(blsPubKey.length == 48);
-
-        return _stakersMap[blsPubKey].balance;
-    }
-
-    function getRewardAddress(
-        bytes calldata blsPubKey
-    ) public view returns (address) {
-        require(blsPubKey.length == 48);
-        if (_stakersMap[blsPubKey].rewardAddress == address(0)) {
-            revert("not staked");
-        }
-        return _stakersMap[blsPubKey].rewardAddress;
-    }
-
-    function getStakers() public view returns (bytes[] memory) {
-        return _stakerKeys;
-    }
-
-    function getStakersData()
-        public
-        view
-        returns (bytes[] memory stakerKeys, Staker[] memory stakers)
-    {
-        stakerKeys = _stakerKeys;
-        stakers = new Staker[](stakerKeys.length);
-        for (uint256 i = 0; i < stakerKeys.length; i++) {
-            stakers[i] = _stakersMap[stakerKeys[i]];
-        }
-    }
-
-    function getPeerId(
-        bytes calldata blsPubKey
-    ) public view returns (bytes memory) {
-        require(blsPubKey.length == 48);
-        if (_stakersMap[blsPubKey].rewardAddress == address(0)) {
-            revert("not staked");
-        }
-        return _stakersMap[blsPubKey].peerId;
-    }
-}
-*/

--- a/src/NonLiquidDelegationV2.sol
+++ b/src/NonLiquidDelegationV2.sol
@@ -3,8 +3,10 @@ pragma solidity ^0.8.26;
 
 import "src/BaseDelegation.sol";
 import "src/NonLiquidDelegation.sol";
+import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 
 contract NonLiquidDelegationV2 is BaseDelegation, INonLiquidDelegation {
+    using SafeCast for int256;
 
     struct Staking {
         //TODO: just for testing purposes, can be removed
@@ -183,7 +185,7 @@ contract NonLiquidDelegationV2 is BaseDelegation, INonLiquidDelegation {
         uint256 newRewards; // no rewards before the first staker is added
         if ($.stakings.length > 0) {
             value += int256($.stakings[$.stakings.length - 1].total);
-            newRewards = _uint256(int256(getRewards()) - $.totalRewards);
+            newRewards = (int256(getRewards()) - $.totalRewards).toUint256();
         }
         $.totalRewards = int256(getRewards());
         //$.stakings.push(Staking(uint256(amount), uint256(value), newRewards));
@@ -240,6 +242,9 @@ contract NonLiquidDelegationV2 is BaseDelegation, INonLiquidDelegation {
         (uint256 result, uint64 i, uint64 index) = additionalSteps == type(uint64).max ?
             _rewards() :
             _rewards(additionalSteps);
+        // the caller has not delegated any stake
+        if (index == 0)
+            return 0;
         uint256 taxedRewards = taxRewards(result);
         $.allWithdrawnRewards[_msgSender()] += taxedRewards;
         $.firstStakingIndex[_msgSender()] = i;
@@ -260,15 +265,6 @@ contract NonLiquidDelegationV2 is BaseDelegation, INonLiquidDelegation {
         return _rewards(type(uint64).max);
     }
 
-    //TODO: The contract assumes that delegators start contributing to the rewards earned by the validator
-    //      from the point when they delegate their stake. However, this is not true since the delegated
-    //      stake is only added to the validator's deposit in the epoch after next. Smilarly, the contract
-    //      assumes that unstaking has immediate effect on the validator's deposit i.e. the delegator's
-    //      contribution to the rewards earned by the validator are descreased accordingly. This is also
-    //      not correct and it could be misused by delegators to maximize their share of the rewards at
-    //      the expense of other delegators by staking in the first and unstaking in the last block of an
-    //      epoch and thereby receiving a share of the rewards for 3599 additional blocks during which the
-    //      validator was actually not earning more rewards due to the stake of the delegator.
     function _rewards(uint64 additionalSteps) internal view returns(uint256 result, uint64 i, uint64 index) {
         NonLiquidDelegationStorage storage $ = _getNonLiquidDelegationStorage();
         uint64 firstIndex;
@@ -290,10 +286,18 @@ contract NonLiquidDelegationV2 is BaseDelegation, INonLiquidDelegation {
                     return (result, i, index);
             }
             // all rewards recorded in the stakings were taken into account
-            if (index == $.stakings.length)
+            if (index == $.stakings.length) {
+                // ensure that the next time the function is called the last index
+                // representing the rewards accrued since the last staking are not
+                // included in the result any more - however, what if there have
+                // been no stakings i.e. the last index remains the same, but there
+                // have been additional rewards - how can we determine the amount of
+                // rewards added since we called _withdrawRewards() last time?
+                index++;
                 // the last step is to add the rewards accrued since the last staking
                 if (total > 0)
-                    result += _uint256(int256(getRewards()) - $.totalRewards) * amount / total;
+                    result += (int256(getRewards()) - $.totalRewards).toUint256() * amount / total;
+            }
         }
         // ensure that the next time the function is called the initial value of i refers
         // to the last amount and total among the stakingIndices of the staker that already
@@ -303,12 +307,6 @@ contract NonLiquidDelegationV2 is BaseDelegation, INonLiquidDelegation {
     }
 
     function collectCommission() public override {}
-
-    function _uint256(int256 num) internal pure returns(uint256 res) {
-        // underflow is intentional as a way of handling
-        // assignments of a negative int256 to an uint256
-        res = num < 0 ? 0 - uint256(num) : uint256(num);
-    }
 
     function supportsInterface(bytes4 interfaceId) public view override returns (bool) {
        return interfaceId == type(INonLiquidDelegation).interfaceId || super.supportsInterface(interfaceId);

--- a/state.sh
+++ b/state.sh
@@ -52,7 +52,11 @@ commissionNumerator=$(cast call $1 "getCommissionNumerator()(uint256)" --block $
 denominator=$(cast call $1 "DENOMINATOR()(uint256)" --block $block_num --rpc-url http://localhost:4201 | sed 's/\[[^]]*\]//g')
 if [[ "$variant" == "ILiquidDelegation" ]]; then
     totalSupply=$(cast call $lst "totalSupply()(uint256)" --block $block_num --rpc-url http://localhost:4201 | sed 's/\[[^]]*\]//g')
-    price=$(bc -l <<< "scale=36; ($stake+$rewardsBeforeUnstaking-($rewardsBeforeUnstaking-$taxedRewardsBeforeUnstaking)*$commissionNumerator/$denominator)/$totalSupply")
+    if [[ $totalSupply -ne 0 ]]; then
+        price=$(bc -l <<< "scale=36; ($stake+$rewardsBeforeUnstaking-($rewardsBeforeUnstaking-$taxedRewardsBeforeUnstaking)*$commissionNumerator/$denominator)/$totalSupply")
+    else
+        price=$(bc -l <<< "scale=36; 1/1")
+    fi
     price0=$(cast call $1 "getPrice()(uint256)" --block $block_num --rpc-url http://localhost:4201 | sed 's/\[[^]]*\]//g')
     echo LST supply: $(cast to-unit $totalSupply ether) ZIL
     echo LST price: $price \~ $(cast to-unit $price0 ether)

--- a/unstake.sh
+++ b/unstake.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ $# -lt 2 ]; then
-    echo "Provide the delegation contract address, a staker private key and optionally the number of shares as arguments."
+    echo "Provide the delegation contract address, a staker private key and optionally how much to unstake as arguments."
     exit 1
 fi
 


### PR DESCRIPTION
Due to the recently introduced (de)activation delay of deposit topups and withdrawals by up to 2 epochs, the LST price calculation was broken, until https://github.com/Zilliqa/zq2/pull/1852 enabled a fix in the `BaseDelegationV2` contract. Other minor things have been improved as well.