### PR TITLE
Fix price volatility on unstaking

### DIFF
--- a/src/BaseDelegation.sol
+++ b/src/BaseDelegation.sol
@@ -31,7 +31,7 @@ library WithdrawalQueue {
         return abi.decode(data, (uint256));
     }
 
-    function queue(Fifo storage fifo, uint256 amount) internal {
+    function enqueue(Fifo storage fifo, uint256 amount) internal {
         fifo.items[fifo.last] = Item(block.number + unbondingPeriod(), amount);
         fifo.last++;
     }
@@ -198,7 +198,7 @@ abstract contract BaseDelegation is Delegation, PausableUpgradeable, Ownable2Ste
 
     function _enqueueWithdrawal(uint256 amount) internal virtual {
         BaseDelegationStorage storage $ = _getBaseDelegationStorage();
-        $.withdrawals[_msgSender()].queue(amount);
+        $.withdrawals[_msgSender()].enqueue(amount);
         $.totalWithdrawals += amount;
     }
 

--- a/src/NonLiquidDelegationV2.sol
+++ b/src/NonLiquidDelegationV2.sol
@@ -166,16 +166,14 @@ contract NonLiquidDelegationV2 is BaseDelegation, INonLiquidDelegation {
     }
 
     function stake() public override payable whenNotPaused {
-        if (_isActivated())
-            _increaseDeposit(msg.value);
+        _increaseDeposit(msg.value);
         _append(int256(msg.value));
         emit Staked(_msgSender(), msg.value, "");
     }
 
     function unstake(uint256 value) public override whenNotPaused {
         _append(-int256(value));
-        if (_isActivated())
-            _decreaseDeposit(uint256(value));
+        _decreaseDeposit(uint256(value));
         _enqueueWithdrawal(value);
         emit Unstaked(_msgSender(), value, "");
     }
@@ -248,8 +246,7 @@ contract NonLiquidDelegationV2 is BaseDelegation, INonLiquidDelegation {
 
     function stakeRewards() public override {
         (uint256 amount, ) = _useRewards(type(uint256).max, type(uint64).max);
-        if (_isActivated())
-            _increaseDeposit(amount);
+        _increaseDeposit(amount);
         _append(int256(amount));
         emit Staked(_msgSender(), amount, "");
     }

--- a/test/LiquidDelegation.t.sol
+++ b/test/LiquidDelegation.t.sol
@@ -533,7 +533,7 @@ contract LiquidDelegationTest is Test {
         console.log("validator withdrew");
         console.log("validator balance: %s", owner.balance);
         //vm.roll(block.number + Deposit(delegation.DEPOSIT_CONTRACT()).withdrawalPeriod());
-        //TODO: once https://github.com/Zilliqa/zq2/issues/1761 is fixed, uncomment the previous line and comment out the next one
+        //TODO: remove the next line and uncomment the previous once https://github.com/Zilliqa/zq2/issues/1761 is fixed
         vm.warp(block.timestamp + Deposit(delegation.DEPOSIT_CONTRACT()).withdrawalPeriod()); // skip(WithdrawalQueue.unbondingPeriod());
         Deposit(delegation.DEPOSIT_CONTRACT()).withdraw();
         console.log("validator withdrew again");


### PR DESCRIPTION
Change the way we withdraw from the deposit when delegators unstake to avoid temporary price volatility.