### PR TITLE
Replace old deposit contract address with deposit proxy address

### DIFF
--- a/src/BaseDelegation.sol
+++ b/src/BaseDelegation.sol
@@ -10,7 +10,7 @@ import "src/Delegation.sol";
 
 library WithdrawalQueue {
 
-    address public constant DEPOSIT_CONTRACT = 0x000000000000000000005a494C4445504F534954;
+    address public constant DEPOSIT_CONTRACT = address(0x5A494C4445504F53495450524F5859);
 
     struct Item {
         uint256 blockNumber;
@@ -75,7 +75,7 @@ abstract contract BaseDelegation is Delegation, PausableUpgradeable, Ownable2Ste
     }
 
     uint256 public constant MIN_DELEGATION = 100 ether;
-    address public constant DEPOSIT_CONTRACT = 0x000000000000000000005a494C4445504F534954;
+    address public constant DEPOSIT_CONTRACT = WithdrawalQueue.DEPOSIT_CONTRACT;
     uint256 public constant DENOMINATOR = 10_000;
 
     function version() public view returns(uint64) {

--- a/state.sh
+++ b/state.sh
@@ -83,8 +83,8 @@ echo validator balance: $(cast to-unit $validatorBalance ether) ZIL
 pendingWithdrawals=$(cast call $1 "getTotalWithdrawals()(uint256)" --block $block_num --rpc-url http://localhost:4201 | sed 's/\[[^]]*\]//g')
 echo pending withdrawals: $(cast to-unit $pendingWithdrawals ether) ZIL
 
-totalStake=$(cast call 0x000000000000000000005a494C4445504F534954 "getFutureTotalStake()(uint256)" --block $block_num --rpc-url http://localhost:4201 | sed 's/\[[^]]*\]//g')
+totalStake=$(cast call 0x00000000005A494C4445504F53495450524F5859 "getFutureTotalStake()(uint256)" --block $block_num --rpc-url http://localhost:4201 | sed 's/\[[^]]*\]//g')
 echo total stake: $(cast to-unit $totalStake ether) ZIL
 
-depositBalance=$(cast rpc eth_getBalance 0x000000000000000000005a494C4445504F534954 $block --rpc-url http://localhost:4201 | tr -d '"' | cast to-dec --base-in 16)
+depositBalance=$(cast rpc eth_getBalance 0x00000000005A494C4445504F53495450524F5859 $block --rpc-url http://localhost:4201 | tr -d '"' | cast to-dec --base-in 16)
 echo deposit balance: $(cast to-unit $depositBalance ether) ZIL

--- a/test/BaseDelegation.t.sol
+++ b/test/BaseDelegation.t.sol
@@ -105,7 +105,7 @@ abstract contract BaseDelegationTest is Test {
         InitialStaker[] memory initialStakers = new InitialStaker[](0);
         //vm.deployCodeTo("Deposit.sol", delegation.DEPOSIT_CONTRACT());
         vm.etch(
-            delegation.DEPOSIT_CONTRACT(), //0x000000000000000000005a494C4445504F534954,
+            delegation.DEPOSIT_CONTRACT(),
             // since the deposit contract is upgradeable, the constructor has no parameters
             //address(new Deposit(10_000_000 ether, 256, 10, initialStakers)).code
             address(new Deposit()).code


### PR DESCRIPTION
It went unnoticed, but the deposit contract's upgradeable proxy has a different address than the old deposit contract used to have. Adjust the delegation contacts to use the new address.