### PR TITLE
Enable multiple validators to join and leave the staking pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Note that the commission rate is specified as an integer to be divided by the `D
 cast call 0x7A0b7e6D24eDe78260c9ddBD98e828B0e11A8EA2 "DENOMINATOR()(uint256)" --rpc-url $RPC_URL  | sed 's/\[[^]]*\]//g'
 ```
 
-Once the validator is activated and starts earning rewards, commissions are transferred automatically to the validator node's account. Commissions of a non-liquid staking validator are deducted when delegators withdraw rewards. In case of the liquid staking variant, commissions are deducted each time delegators stake, unstake or claim what they unstaked, or when the node requests the outstanding commissions that haven't been transferred yet. To collect them, run
+Once the validator is activated and starts earning rewards, commissions are transferred automatically to the owner account. Commissions of a non-liquid staking validator are deducted when delegators withdraw rewards. In case of the liquid staking variant, commissions are deducted each time delegators stake, unstake or claim what they unstaked, or when the contract owner requests the outstanding commissions that haven't been transferred yet. To collect them, run
 ```bash
 forge script script/ManageCommission.s.sol --rpc-url $RPC_URL --broadcast --legacy --sig "run(address payable, string, bool)" 0x7A0b7e6D24eDe78260c9ddBD98e828B0e11A8EA2 same true
 ```
@@ -98,53 +98,51 @@ using `same` for the second argument to leave the commission percentage unchange
 
 ## Validator Activation or Migration
 
-If your node has already been activated as a validator i.e. solo staker, you can migrate it to a staking pool. Run
+If your node has already been activated as a validator i.e. solo staker, it can join a staking pool. Run
 ```bash
 cast send --legacy --rpc-url $RPC_URL --private-key 0x... \
 0x00000000005a494c4445504f53495450524f5859 "setControlAddress(bytes,address)" \
 0x92fbe50544dce63cfdcc88301d7412f0edea024c91ae5d6a04c7cd3819edfc1b9d75d9121080af12e00f054d221f876c \
 0x7A0b7e6D24eDe78260c9ddBD98e828B0e11A8EA2
 ```
-using the private key you used to deposit your nodes, the BLS public key of your node and the address of your delegation contract. Afterwards run
+using the private key that you used to deposit your node, the BLS public key of your node and the address of the staking pool's delegation contract. Afterwards the staking pool contract owner must run
 ```bash
 cast send --legacy --rpc-url $RPC_URL --private-key $PRIVATE_KEY \
-0x7a0b7e6d24ede78260c9ddbd98e828b0e11a8ea2 "migrate(bytes)" \
+0x7a0b7e6d24ede78260c9ddbd98e828b0e11a8ea2 "join(bytes,address)" \
+0x92fbe50544dce63cfdcc88301d7412f0edea024c91ae5d6a04c7cd3819edfc1b9d75d9121080af12e00f054d221f876c \
+0xe0c6f3d59b8cda6ce4fd66418212404a63ad8517
+```
+using the BLS public key and the original control address that you used when you deposited the node. 
+
+To leave a staking pool, run 
+```bash
+cast send --legacy --rpc-url $RPC_URL --private-key 0x... \
+0x7a0b7e6d24ede78260c9ddbd98e828b0e11a8ea2 "leave(bytes)" \
 0x92fbe50544dce63cfdcc88301d7412f0edea024c91ae5d6a04c7cd3819edfc1b9d75d9121080af12e00f054d221f876c
 ```
-using the BLS public key of your node.
+using the private key that you used to deposit your node, the BLS public key of your node and the address of the staking pool's delegation contract. After leaving the pool, your node will remain a validator.
 
-If your node hasn't been deposited yet but the owner account has enough ZIL for the minimum stake required, you can activate your node as a validator with a deposit of e.g. 10 million ZIL. Run
+Note that if your node's entire deposit is unstaked, it gets automatically removed from the validator set and the staking pool as well.
+
+If you don't have an activated validator node yet, but have already deployed a delegation contract, it can start accepting delegated stake, and as soon as the funds collected plus your balance as the contract owner can cover the required minimum stake, you can make a fully synced node the first validator of your staking pool by submitting a transaction with e.g. additional 5 million ZIL through
 ```bash
-cast send --legacy --value 10000000ether --rpc-url $RPC_URL --private-key $PRIVATE_KEY \
-0x7a0b7e6d24ede78260c9ddbd98e828b0e11a8ea2 "depositFirst(bytes,bytes,bytes)" \
+cast send --legacy --value 5000000ether --rpc-url $RPC_URL --private-key $PRIVATE_KEY \
+0x7a0b7e6d24ede78260c9ddbd98e828b0e11a8ea2 "deposit(bytes,bytes,bytes)" \
 0x92fbe50544dce63cfdcc88301d7412f0edea024c91ae5d6a04c7cd3819edfc1b9d75d9121080af12e00f054d221f876c \
 0x002408011220d5ed74b09dcbe84d3b32a56c01ab721cf82809848b6604535212a219d35c412f \
 0xb14832a866a49ddf8a3104f8ee379d29c136f29aeb8fccec9d7fb17180b99e8ed29bee2ada5ce390cb704bc6fd7f5ce814f914498376c4b8bc14841a57ae22279769ec8614e2673ba7f36edc5a4bf5733aa9d70af626279ee2b2cde939b4bd8a
 ```
-with the BLS public key, the peer id and the BLS signature of your node. Note that the peer id must be converted from base58 to hexadecimal format and you must provide the delegation contract address when generating the BLS signature:
+with the BLS public key, the peer id and the BLS signature of the node. Note that the peer id must be converted from base58 to hexadecimal format and you must provide the delegation contract address when generating the BLS signature:
 ```bash
 echo '{"secret_key":"...", "chain_id":..., "control_address":"0x7a0b7e6d24ede78260c9ddbd98e828b0e11a8ea2"}' | cargo run --bin convert-key
 ```
-Make sure your node is fully synced before you run the above command.
 
-Note that the reward address registered for your validator node will be the address of the delegation contract (the proxy contract to be more precise).
-
-Alternatively, you can proceed to the next section and accept delegated stake until the contract's balance reaches the minimum stake required for the activation, and then run
-```bash
-cast send --legacy --rpc-url $RPC_URL --private-key $PRIVATE_KEY \
-0x7a0b7e6d24ede78260c9ddbd98e828b0e11a8ea2 "depositLater(bytes,bytes,bytes)" \
-0x92fbe50544dce63cfdcc88301d7412f0edea024c91ae5d6a04c7cd3819edfc1b9d75d9121080af12e00f054d221f876c \
-0x002408011220d5ed74b09dcbe84d3b32a56c01ab721cf82809848b6604535212a219d35c412f \
-0xb14832a866a49ddf8a3104f8ee379d29c136f29aeb8fccec9d7fb17180b99e8ed29bee2ada5ce390cb704bc6fd7f5ce814f914498376c4b8bc14841a57ae22279769ec8614e2673ba7f36edc5a4bf5733aa9d70af626279ee2b2cde939b4bd8a
-```
-to deposit all of it.
-
-Note that the deposit will not take effect and the node will not start earning rewards until the epoch after next.
+Note that the reward address registered for the validator node will be the address of the delegation contract (the proxy contract to be more precise), but the deposit will not take effect and the node will not start to earn rewards until the epoch after next.
 
 
 ## Staking and Unstaking
 
-Once the delegation contract has been deployed and upgraded to the latest version, your node can accept delegations. In order to stake e.g. 200 ZIL, run
+Once the delegation contract has been deployed and upgraded to the latest version, it can accept delegations. In order to stake e.g. 200 ZIL, run
 ```bash
 forge script script/Stake.s.sol --rpc-url $RPC_URL --broadcast --legacy --sig "run(address payable, uint256)" 0x7A0b7e6D24eDe78260c9ddBD98e828B0e11A8EA2 200000000000000000000 --private-key 0x...
 ```
@@ -223,6 +221,8 @@ cast to-unit $(cast call 0x7A0b7e6D24eDe78260c9ddBD98e828B0e11A8EA2 "getClaimabl
 ```
 with the address of the account that unstaked above as an argument.
 
+Note that an unstaking transaction will fail if any validator's deposit falls below the minimum stake required of validators. If you used stake delegated to your contract instead of your own funds to deposit your first validator node, you should increase your stake as soon as possible to ensure that your delegators are able to unstake. 
+
 Of course, delegators will not be using the CLI to stake, unstake and claim their funds. To enable delegators to access your staking pool through the staking portal maintained by the Zilliqa team, get in touch and provide your delegation contract address once you have set up the validator node and delegation contract. If you want to integrate staking into your dapp, see the [Development and Testing](#development-and-testing) section below.
 
 
@@ -263,10 +263,15 @@ Staking pool operators are encouraged to fork and adapt the above contracts to i
 
 The tests included in this repository should also be adjusted and extended accordingly. They can be executed by running
 ```bash
-PRIVATE_KEY="0x$(openssl rand -hex 32)" forge test
+forge test
 ```
+or
+```bash
+forge test -vv
+```
+if you want to see the values calculated in the tests.
 
-To enable the tests to interact with the Zilliqa 2.0 deposit contract, the contract must be compiled along with the test contracts. Specify the folder containing the `deposit.sol` file in `remappings.txt`:
+To enable the tests to interact with the Zilliqa 2.0 deposit contract, the contract must be compiled along with the test contracts. Specify the folder containing the Solidity file in `remappings.txt`:
 ```
 @zilliqa/zq2/=/home/user/zq2/zilliqa/src/contracts/
 ```

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Note that the commission rate is specified as an integer to be divided by the `D
 cast call 0x7A0b7e6D24eDe78260c9ddBD98e828B0e11A8EA2 "DENOMINATOR()(uint256)" --rpc-url $RPC_URL  | sed 's/\[[^]]*\]//g'
 ```
 
-Once the validator is activated and starts earning rewards, commissions are transferred automatically to the owner account. Commissions of a non-liquid staking validator are deducted when delegators withdraw rewards. In case of the liquid staking variant, commissions are deducted each time delegators stake, unstake or claim what they unstaked, or when the contract owner requests the outstanding commissions that haven't been transferred yet. To collect them, run
+Once the validator is activated and starts earning rewards, commissions are transferred automatically to the owner account. Commissions of a non-liquid staking validator are deducted when delegators withdraw or stake rewards. In case of the liquid staking variant, commissions are deducted each time delegators stake, unstake or claim what they unstaked, or when the contract owner requests the outstanding commissions that haven't been transferred yet. To collect them, run
 ```bash
 forge script script/ManageCommission.s.sol --rpc-url $RPC_URL --broadcast --legacy --sig "run(address payable, string, bool)" 0x7A0b7e6D24eDe78260c9ddBD98e828B0e11A8EA2 same true
 ```

--- a/script/Upgrade.s.sol
+++ b/script/Upgrade.s.sol
@@ -47,7 +47,7 @@ contract Upgrade is Script {
         );
 
         bytes memory reinitializerCall = abi.encodeWithSignature(
-            "reinitialize()"
+            oldDelegation.version() > 2 ? "migrateFromV2()" : "reinitialize()"
         );
 
         oldDelegation.upgradeToAndCall(

--- a/script/Upgrade.s.sol
+++ b/script/Upgrade.s.sol
@@ -23,8 +23,9 @@ contract Upgrade is Script {
             proxy
         );
 
+        uint64 oldVersion = oldDelegation.version();
         console.log("Upgrading from version: %s",
-            oldDelegation.version()
+            oldVersion
         );
 
         console.log("Owner is %s",
@@ -47,7 +48,8 @@ contract Upgrade is Script {
         );
 
         bytes memory reinitializerCall = abi.encodeWithSignature(
-            oldDelegation.version() > 2 ? "migrateFromV2()" : "reinitialize()"
+            "reinitialize(uint64)",
+            oldVersion
         );
 
         oldDelegation.upgradeToAndCall(

--- a/src/BaseDelegation.sol
+++ b/src/BaseDelegation.sol
@@ -12,19 +12,21 @@ abstract contract BaseDelegation is IDelegation, PausableUpgradeable, Ownable2St
 
     using WithdrawalQueue for WithdrawalQueue.Fifo;
 
+    enum ValidatorStatus {Active, PreparingToLeave, WaitingToLeave, ReadyToLeave}
+
     struct Validator {
         bytes blsPubKey;
         uint256 futureStake;
         address rewardAddress;
         address controlAddress;
         uint256 pendingWithdrawals;
-        bool expectedToLeave;
+        ValidatorStatus status;
     }
 
     /// @custom:storage-location erc7201:zilliqa.storage.BaseDelegation
     struct BaseDelegationStorage {
-//TODO: blsPubKey can't be removed, its slot must be occupied 
-        bytes blsPubKey;
+        // the actual position in the validators array is the validatorIndex - 1 
+        mapping(bytes => uint256) validatorIndex;
         bool activated;
         uint256 commissionNumerator;
         mapping(address => WithdrawalQueue.Fifo) withdrawals;
@@ -42,17 +44,40 @@ abstract contract BaseDelegation is IDelegation, PausableUpgradeable, Ownable2St
         }
     }
 
-    uint256 public constant MIN_DELEGATION = 100 ether;
+    uint256 public constant MIN_DELEGATION = 10 ether;
     address public constant DEPOSIT_CONTRACT = WithdrawalQueue.DEPOSIT_CONTRACT;
     uint256 public constant DENOMINATOR = 10_000;
 
-    event ValidatorJoined(bytes blsPubKey);
-    event ValidatorLeft(bytes blsPubKey);
-    event ValidatorExpectedToLeave(bytes blsPubKey);
+    event ValidatorJoined(bytes indexed blsPubKey);
+    event ValidatorLeft(bytes indexed blsPubKey);
+    event ValidatorLeaving(bytes indexed blsPubKey, bool success);
+
+    // use semver instead of simple incremental version numbers
+    // contract file names remain the same across all versions
+    // so that the upgrade script does not need to be modified
+    // to import the new version each time there is one
+    uint64 internal immutable VERSION = encodeVersion(0, 2, 0);
 
     function version() public view returns(uint64) {
         return _getInitializedVersion();
     } 
+
+    function decodedVersion() public view returns(uint24, uint24, uint24) {
+        return decodeVersion(_getInitializedVersion());
+    } 
+
+    function encodeVersion(uint24 major, uint24 minor, uint24 patch) pure public returns(uint64) {
+        require(major < 2*20, "incorrect major version");
+        require(minor < 2*20, "incorrect minor version");
+        require(patch < 2*20, "incorrect patch version");
+        return uint64(major * 2**40 + minor * 2**20 + patch);
+    }
+
+    function decodeVersion(uint64 v) pure public returns(uint24 major, uint24 minor, uint24 patch) {
+        patch = uint24(v & (2**20 - 1));
+        minor = uint24((v >> 20) & (2**20 - 1)); 
+        major = uint24((v >> 40) & (2**20 - 1)); 
+    }
 
     // solhint-disable func-name-mixedcase
     function __BaseDelegation_init(address initialOwner) internal onlyInitializing {
@@ -77,11 +102,14 @@ abstract contract BaseDelegation is IDelegation, PausableUpgradeable, Ownable2St
         if (fromVersion == 1)
             return;
 
+        // the previous version is higher or same as the current version
+        if (fromVersion >= VERSION)
+            return;
+
         BaseDelegationStorage storage $ = _getBaseDelegationStorage();
 
-//TODO: remove
-//        if ($.blsPubKey.length == 0)
-        // the contract has been upgraded but the length of the peerId is zero
+        // the contract has been upgraded but the length of the peerId
+        // stored in the same slot as the activated bool is zero
         if (!$.activated)
             return;
 
@@ -89,10 +117,11 @@ abstract contract BaseDelegation is IDelegation, PausableUpgradeable, Ownable2St
         uint256 peerIdLength;
         assembly {
             temp.slot := BaseDelegationStorageLocation
-            peerIdLength := sload(add(BaseDelegationStorageLocation, 0x20))
+            peerIdLength := sload(add(BaseDelegationStorageLocation, 1))
         }
 
-        // the upgraded contract has already been migrated since the peerId storage slot contains boolean true
+        // if the upgraded contract hadn't been migrated yet then the peerIdLength stored
+        // in the same slot as activated would be larger, but it was overwritten with true
         if (peerIdLength == 1)
             return;
 
@@ -106,12 +135,16 @@ abstract contract BaseDelegation is IDelegation, PausableUpgradeable, Ownable2St
             owner(),
             owner(),
             0,
-            false
+            ValidatorStatus.Active
         ));
 
+        $.validatorIndex[temp.blsPubKey] = $.validators.length;
+
+        // it overwrites the peerId length with 1 and prevents repeating the whole migration again
         $.activated = true;
-//TODO: remove
-//        $.blsPubKey = "";
+
+        // remove the blsPubKey stored in the same slot at the validatorIndex of 0x before the migration 
+        delete $.validatorIndex[""];
     }
 
     function _authorizeUpgrade(address newImplementation) internal onlyOwner virtual override {}
@@ -120,8 +153,7 @@ abstract contract BaseDelegation is IDelegation, PausableUpgradeable, Ownable2St
         BaseDelegationStorage storage $ = _getBaseDelegationStorage();
         $.activated = true;
 
-        for (uint256 i = 0; i < $.validators.length; i++)
-            require(keccak256($.validators[i].blsPubKey) != keccak256(blsPubKey), "validator with provided bls pub key already added");
+        require($.validatorIndex[blsPubKey] == 0, "validator with provided bls pub key already added");
 
         (bool success, bytes memory data) = DEPOSIT_CONTRACT.call(abi.encodeWithSignature("getFutureStake(bytes)", blsPubKey));
         require(success, "future stake could not be retrieved");
@@ -142,36 +174,88 @@ abstract contract BaseDelegation is IDelegation, PausableUpgradeable, Ownable2St
             rewardAddress,
             controlAddress,
             0,
-            false
+            ValidatorStatus.Active
         ));
+        $.validatorIndex[blsPubKey] = $.validators.length;
         emit ValidatorJoined(blsPubKey);
     }
 
-    function _leave(bytes calldata blsPubKey) internal virtual {
+    function completeLeaving(bytes calldata blsPubKey) public virtual {
         BaseDelegationStorage storage $ = _getBaseDelegationStorage();
-
-        for (uint256 i = 0; i < $.validators.length; i++)
-            if (keccak256($.validators[i].blsPubKey) == keccak256(blsPubKey)) {
-                require(_msgSender() == $.validators[i].controlAddress, "only the control address can initiate leaving");
-                if ($.validators[i].pendingWithdrawals > 0) {
-                    $.validators[i].expectedToLeave = true;
-                    emit ValidatorExpectedToLeave($.validators[i].blsPubKey);
-                } else {
-                    (bool success, ) = DEPOSIT_CONTRACT.call(abi.encodeWithSignature("setRewardAddress(bytes,address)", $.validators[i].blsPubKey, $.validators[i].rewardAddress));
-                    require(success, "reward address could not be changed");
-
-                    (success, ) = DEPOSIT_CONTRACT.call(abi.encodeWithSignature("setControlAddress(bytes,address)", $.validators[i].blsPubKey, $.validators[i].controlAddress));
-                    require(success, "control address could not be changed");
-
-                    emit ValidatorLeft($.validators[i].blsPubKey);
-
-                    if (i < $.validators.length - 1)
-                        $.validators[i] = $.validators[$.validators.length - 1];
-                    $.validators.pop();
-                }
-                return;
+        uint256 i = $.validatorIndex[blsPubKey];
+        require(i-- > 0, "validator with provided bls key not found");
+        require(_msgSender() == $.validators[i].controlAddress, "only the control address can complete leaving");                
+        require($.validators[i].status >= ValidatorStatus.WaitingToLeave, "the control address has not initiated leaving yet");
+        if ($.validators[i].status == ValidatorStatus.WaitingToLeave) {
+            // currently all validators have the same reward address, which is the address of this delegation contract
+            uint256 amount = address(this).balance;
+            (bool success, ) = DEPOSIT_CONTRACT.call(
+                abi.encodeWithSignature("withdraw(bytes)",
+                    $.validators[i].blsPubKey
+                )
+            );
+            require(success, "deposit withdrawal failed");
+            amount = address(this).balance - amount;
+            if (amount > 0) {
+                _increaseDeposit(amount);
+                $.validators[i].status = ValidatorStatus.ReadyToLeave;
             }
-        revert("validator with provided bls key not found");
+        }
+        if ($.validators[i].status == ValidatorStatus.ReadyToLeave) {
+            (bool success, ) = DEPOSIT_CONTRACT.call(abi.encodeWithSignature("setRewardAddress(bytes,address)", $.validators[i].blsPubKey, $.validators[i].rewardAddress));
+            require(success, "reward address could not be changed");
+
+            (success, ) = DEPOSIT_CONTRACT.call(abi.encodeWithSignature("setControlAddress(bytes,address)", $.validators[i].blsPubKey, $.validators[i].controlAddress));
+            require(success, "control address could not be changed");
+
+            emit ValidatorLeft($.validators[i].blsPubKey);
+
+            delete $.validatorIndex[$.validators[i].blsPubKey];
+            if (i < $.validators.length - 1) {
+                $.validators[i] = $.validators[$.validators.length - 1];
+                $.validatorIndex[$.validators[i].blsPubKey] = i + 1;
+            }
+            $.validators.pop();
+        }
+    }
+
+    function _preparedToLeave(bytes calldata blsPubKey) internal virtual returns(bool prepared) {
+        BaseDelegationStorage storage $ = _getBaseDelegationStorage();
+        uint256 i = $.validatorIndex[blsPubKey];
+        require(i-- > 0, "validator with provided bls key not found");
+        prepared = $.validators[i].pendingWithdrawals == 0;
+        $.validators[i].status = ValidatorStatus.PreparingToLeave;
+        emit ValidatorLeaving(blsPubKey, prepared);
+    }
+
+    function _initiateLeaving(bytes calldata blsPubKey, uint256 leavingStake) internal virtual {
+        BaseDelegationStorage storage $ = _getBaseDelegationStorage();
+        uint256 i = $.validatorIndex[blsPubKey];
+        require(i-- > 0, "validator with provided bls key not found");
+        require(_msgSender() == $.validators[i].controlAddress, "only the control address can initiate leaving");                
+        require($.validators[i].status == ValidatorStatus.PreparingToLeave, "validator is not prepared to leave");
+        if ($.validators[i].pendingWithdrawals == 0)
+            if ($.validators[i].futureStake > leavingStake) {
+                $.validators[i].status = ValidatorStatus.WaitingToLeave;
+                (bool success, ) = DEPOSIT_CONTRACT.call(
+                    abi.encodeWithSignature("unstake(bytes,uint256)",
+                        $.validators[i].blsPubKey,
+                        $.validators[i].futureStake - leavingStake
+                    )
+                );
+                require(success, "deposit decrease failed");
+                $.validators[i].futureStake = leavingStake;
+            } else {
+                $.validators[i].status = ValidatorStatus.ReadyToLeave;
+                completeLeaving(blsPubKey);
+            }
+    }
+
+    function pendingWithdrawals(bytes calldata blsPubKey) public virtual view returns(bool) {
+        BaseDelegationStorage storage $ = _getBaseDelegationStorage();
+        uint256 i = $.validatorIndex[blsPubKey];
+        require(i-- > 0, "validator with provided bls key not found");                
+        return $.validators[i].pendingWithdrawals > 0;
     }
 
     function validators() public view returns(Validator[] memory) {
@@ -194,8 +278,11 @@ abstract contract BaseDelegation is IDelegation, PausableUpgradeable, Ownable2St
             owner(),
             owner(),
             0,
-            false
+            ValidatorStatus.Active
         ));
+
+        $.validatorIndex[blsPubKey] = $.validators.length;
+
         (bool success, ) = DEPOSIT_CONTRACT.call{
             value: depositAmount
         }(
@@ -208,6 +295,7 @@ abstract contract BaseDelegation is IDelegation, PausableUpgradeable, Ownable2St
             )
         );
         require(success, "deposit failed");
+
         emit ValidatorJoined(blsPubKey);
     }
 
@@ -221,23 +309,21 @@ abstract contract BaseDelegation is IDelegation, PausableUpgradeable, Ownable2St
         bytes calldata signature
     ) public virtual payable;
 
-    // topup the deposits proportionally to the validators' current stake
-    //TODO: alternative strategy: always increase the smallest validator's deposit
+    // topup the deposits proportionally to the validators' current deposit
     function _increaseDeposit(uint256 amount) internal virtual {
         // topup the deposit only if already activated as a validator
         if (_isActivated()) {
             BaseDelegationStorage storage $ = _getBaseDelegationStorage();
-            bool[] memory partake = new bool[]($.validators.length);
-            uint256 totalStake;
+            uint256[] memory contribution = new uint256[]($.validators.length);
+            uint256 total;
+            for (uint256 i = 0; i < $.validators.length; i++) {
+                contribution[i] = $.validators[i].futureStake;
+                total += contribution[i];
+            }
+            require(total > 0, "no validators in the staking pool");
             for (uint256 i = 0; i < $.validators.length; i++)
-                if (!$.validators[i].expectedToLeave) {
-                    totalStake += $.validators[i].futureStake;
-                    partake[i] = true;
-                }
-            require(totalStake > 0, "no validator's deposit can be increased");
-            for (uint256 i = 0; i < $.validators.length; i++)
-                if (partake[i]) {
-                    uint256 value = amount * $.validators[i].futureStake / totalStake;
+                if (contribution[i] > 0) {
+                    uint256 value = amount * contribution[i] / total;
                     $.validators[i].futureStake += value;
                     (bool success, ) = DEPOSIT_CONTRACT.call{
                         value: value
@@ -251,54 +337,42 @@ abstract contract BaseDelegation is IDelegation, PausableUpgradeable, Ownable2St
         }
     }
 
-    // unstake from the deposits proportionally to the validators' current stake
-    //TODO: alternative strategy: always decrease the largest validator's deposit
+    // unstake from the deposits proportionally to the validators' surplus exceeding the required minimum deposit
     function _decreaseDeposit(uint256 amount) internal virtual {
         // unstake the deposit only if already activated as a validator
         if (_isActivated()) {
-            BaseDelegationStorage storage $ = _getBaseDelegationStorage();
-            bool[] memory partake = new bool[]($.validators.length);
-            uint256 totalStake;
-            for (uint256 i = 0; i < $.validators.length; i++)
-                if (!$.validators[i].expectedToLeave) {
-                    totalStake += $.validators[i].futureStake;
-                    partake[i] = true;
-                }
-            require(totalStake > 0, "no validator's deposit can be decreased");
             (bool success, bytes memory data) = DEPOSIT_CONTRACT.call(
                 abi.encodeWithSignature("minimumStake()")
             );
             require(success, "minimum deposit unknown");
             uint256 minimumDeposit = abi.decode(data, (uint256));
+            BaseDelegationStorage storage $ = _getBaseDelegationStorage();
+            uint256[] memory contribution = new uint256[]($.validators.length);
+            uint256 total;
             for (uint256 i = 0; i < $.validators.length; i++)
-                if (partake[i])
-                    if ($.validators[i].futureStake < minimumDeposit + amount) {
-                        $.validators[i].expectedToLeave = true;
-                        emit ValidatorExpectedToLeave($.validators[i].blsPubKey);
-                    } else {
-                        uint256 value = amount * $.validators[i].futureStake / totalStake;
-                        $.validators[i].futureStake -= value;
-                        $.validators[i].pendingWithdrawals += value;
-                        (success, ) = DEPOSIT_CONTRACT.call(
-                            abi.encodeWithSignature("unstake(bytes,uint256)",
-                                $.validators[i].blsPubKey,
-                                value
-                            )
-                        );
-                        require(success, "deposit decrease failed");
-                    }
-/*TODO: remove
-            // if the validator's stake becomes zero it's removed from the committee
-            // hence it must be removed from the staking pool too otherwise the next
-            // attempt to increase or decrease its deposit will fail
-            if ($.validators[$.validators.length - 1].futureStake == 0)
-                _remove($.validators.length - 1);
-*/
+                if ($.validators[i].status == ValidatorStatus.Active) {
+                    contribution[i] = $.validators[i].futureStake - minimumDeposit;
+                    total += contribution[i];
+                }
+            require(total >= amount, "available deposits insufficient");
+            for (uint256 i = 0; i < $.validators.length; i++)
+                if (contribution[i] > 0) {
+                    uint256 value = amount * contribution[i] / total;
+                    $.validators[i].futureStake -= value;
+                    $.validators[i].pendingWithdrawals += value;
+                    (success, ) = DEPOSIT_CONTRACT.call(
+                        abi.encodeWithSignature("unstake(bytes,uint256)",
+                            $.validators[i].blsPubKey,
+                            value
+                        )
+                    );
+                    require(success, "deposit decrease failed");
+                }
         }
     }
 
     // withdraw the pending unstaked deposits of all validators
-    //TODO: measure how much gas it costs if there is nothing to withdraw yet
+    //TODO: measure how much gas it wastes if there is nothing to withdraw yet
     function _withdrawDeposit() internal virtual {
         // withdraw the unstaked deposit only if already activated as a validator
         if (_isActivated()) {
@@ -314,8 +388,6 @@ abstract contract BaseDelegation is IDelegation, PausableUpgradeable, Ownable2St
                         )
                     );
                     require(success, "deposit withdrawal failed");
-                    // currently all validators have the same reward address,
-                    // which is the address of this delegation contract
                     amount = address(this).balance - amount;
                     $.validators[i].pendingWithdrawals -= amount;
                 }
@@ -387,8 +459,9 @@ abstract contract BaseDelegation is IDelegation, PausableUpgradeable, Ownable2St
 
     function _dequeueWithdrawals() internal virtual returns (uint256 total) {
         BaseDelegationStorage storage $ = _getBaseDelegationStorage();
-        while ($.withdrawals[_msgSender()].ready())
-            total += $.withdrawals[_msgSender()].dequeue().amount;
+        WithdrawalQueue.Fifo storage fifo = $.withdrawals[_msgSender()];
+        while (fifo.ready())
+            total += fifo.dequeue().amount;
         $.totalWithdrawals -= total;
     }
 

--- a/src/BaseDelegation.sol
+++ b/src/BaseDelegation.sol
@@ -506,6 +506,10 @@ abstract contract BaseDelegation is IDelegation, PausableUpgradeable, Ownable2St
     }
 
     function getStake(bytes calldata blsPubKey) public virtual view returns(uint256) {
+        BaseDelegationStorage storage $ = _getBaseDelegationStorage();
+        uint256 i = $.validatorIndex[blsPubKey];
+        if (i > 0)
+            return $.validators[--i].futureStake;
         (bool success, bytes memory data) = DEPOSIT_CONTRACT.staticcall(
             abi.encodeWithSignature("getFutureStake(bytes)", blsPubKey)
         );

--- a/src/BaseDelegation.sol
+++ b/src/BaseDelegation.sol
@@ -169,7 +169,7 @@ abstract contract BaseDelegation is IDelegation, PausableUpgradeable, Ownable2St
         bytes calldata blsPubKey,
         bytes calldata peerId,
         bytes calldata signature
-    ) public virtual;
+    ) public virtual payable;
 
     function _increaseDeposit(uint256 amount) internal virtual {
         // topup the deposit only if already activated as a validator

--- a/src/BaseDelegation.sol
+++ b/src/BaseDelegation.sol
@@ -67,9 +67,9 @@ abstract contract BaseDelegation is IDelegation, PausableUpgradeable, Ownable2St
     } 
 
     function encodeVersion(uint24 major, uint24 minor, uint24 patch) pure public returns(uint64) {
-        require(major < 2*20, "incorrect major version");
-        require(minor < 2*20, "incorrect minor version");
-        require(patch < 2*20, "incorrect patch version");
+        require(major < 2**20, "incorrect major version");
+        require(minor < 2**20, "incorrect minor version");
+        require(patch < 2**20, "incorrect patch version");
         return uint64(major * 2**40 + minor * 2**20 + patch);
     }
 

--- a/src/LiquidDelegation.sol
+++ b/src/LiquidDelegation.sol
@@ -57,7 +57,7 @@ contract LiquidDelegation is BaseDelegation, ILiquidDelegation {
         bytes calldata,
         bytes calldata,
         bytes calldata
-    ) public pure override {
+    ) public override payable {
         revert("not implemented");
     }
 

--- a/src/LiquidDelegation.sol
+++ b/src/LiquidDelegation.sol
@@ -45,7 +45,7 @@ contract LiquidDelegation is BaseDelegation, ILiquidDelegation {
         return $.lst;
     }
 
-    function depositFirst(
+    function deposit(
         bytes calldata,
         bytes calldata,
         bytes calldata
@@ -53,15 +53,11 @@ contract LiquidDelegation is BaseDelegation, ILiquidDelegation {
         revert("not implemented");
     }
 
-    function depositLater(
-        bytes calldata,
-        bytes calldata,
-        bytes calldata
-    ) public override payable {
+    function join(bytes calldata, address) public pure override {
         revert("not implemented");
     }
 
-    function migrate(bytes calldata) public pure override {
+    function leave(bytes calldata) public pure override {
         revert("not implemented");
     }
 

--- a/src/LiquidDelegationV2.sol
+++ b/src/LiquidDelegationV2.sol
@@ -29,8 +29,9 @@ contract LiquidDelegationV2 is BaseDelegation, ILiquidDelegation {
         _disableInitializers();
     }
 
-    //TODO: use a hardcoded version number instead
-    function reinitialize() public reinitializer(version() + 1) {
+//TODO: use a hardcoded version number instead
+    function reinitialize(uint64 fromVersion) public reinitializer(version() + 1) {
+        migrate(fromVersion);
     }
 
     // called when stake withdrawn from the deposit contract is claimed
@@ -86,8 +87,6 @@ contract LiquidDelegationV2 is BaseDelegation, ILiquidDelegation {
             peerId,
             signature,
             getStake()
-//TODO: remove
-//            address(this).balance
         );
     } 
 
@@ -210,8 +209,6 @@ contract LiquidDelegationV2 is BaseDelegation, ILiquidDelegation {
         taxRewards();
         // we must not deposit the funds we need to pay out the claims
         uint256 amount = getRewards();
-//TODO: remove
-//        uint256 amount = address(this).balance;
         if (amount > getTotalWithdrawals()) {
             // not only the rewards (balance) must be reduced
             // by the deposit topup but also the taxed rewards

--- a/src/NonLiquidDelegation.sol
+++ b/src/NonLiquidDelegation.sol
@@ -40,7 +40,7 @@ contract NonLiquidDelegation is BaseDelegation, INonLiquidDelegation {
         __BaseDelegation_init(initialOwner);
     }
 
-    function depositFirst(
+    function deposit(
         bytes calldata,
         bytes calldata,
         bytes calldata
@@ -48,15 +48,11 @@ contract NonLiquidDelegation is BaseDelegation, INonLiquidDelegation {
         revert("not implemented");
     }
 
-    function depositLater(
-        bytes calldata,
-        bytes calldata,
-        bytes calldata
-    ) public override payable {
+    function join(bytes calldata, address) public pure override {
         revert("not implemented");
     }
 
-    function migrate(bytes calldata) public pure override {
+    function leave(bytes calldata) public pure override {
         revert("not implemented");
     }
 

--- a/src/NonLiquidDelegation.sol
+++ b/src/NonLiquidDelegation.sol
@@ -52,7 +52,7 @@ contract NonLiquidDelegation is BaseDelegation, INonLiquidDelegation {
         bytes calldata,
         bytes calldata,
         bytes calldata
-    ) public pure override {
+    ) public override payable {
         revert("not implemented");
     }
 

--- a/src/NonLiquidDelegationV2.sol
+++ b/src/NonLiquidDelegationV2.sol
@@ -44,8 +44,8 @@ contract NonLiquidDelegationV2 is BaseDelegation, INonLiquidDelegation {
         // the amount that has already been withdrawn from the
         // constantly growing rewards accrued since the last staking
         mapping(address => uint256) withdrawnAfterLastStaking;
-        // balance of the reward address minus the
-        // rewards accrued since the last staking
+        // the balance of the reward address without the rewards
+        // accrued since the last staking
         int256 totalRewards;
     }
 
@@ -116,14 +116,18 @@ contract NonLiquidDelegationV2 is BaseDelegation, INonLiquidDelegation {
     event RewardPaid(address indexed delegator, uint256 reward);
 
     // called by the node's owner who deployed this contract
-    // to turn the already deposited validator node into a staking pool
+    // to add an already deposited validator node to the staking pool
+//TODO: rename to join() and adjust the readme
     function migrate(bytes calldata blsPubKey) public override onlyOwner {
         _migrate(blsPubKey);
-        NonLiquidDelegationStorage storage $ = _getNonLiquidDelegationStorage();
-        require($.stakings.length == 0, "stake already delegated");
-        // the owner's deposit must also be recorded as staking otherwise
-        // the owner would not benefit from the rewards accrued by the deposit
-        _append(int256(getStake()));
+
+//TODO: uncomment or remove the next 2 lines depending on whether migration works without it
+        //NonLiquidDelegationStorage storage $ = _getNonLiquidDelegationStorage();
+        //require($.stakings.length == 0, "stake already delegated");
+
+        // the node's deposit must also be recorded as staking otherwise
+        // its owner would not benefit from the rewards accrued due to that deposit
+        _append(int256(getStake(blsPubKey)));
     }
 
     // called by the node's owner who deployed this contract

--- a/src/NonLiquidDelegationV2.sol
+++ b/src/NonLiquidDelegationV2.sol
@@ -9,7 +9,6 @@ contract NonLiquidDelegationV2 is BaseDelegation, INonLiquidDelegation {
     using SafeCast for int256;
 
     struct Staking {
-        //TODO: just for testing purposes, can be removed
         address staker;
         // the currently staked amount of the staker
         // after the staking/unstaking
@@ -139,9 +138,10 @@ contract NonLiquidDelegationV2 is BaseDelegation, INonLiquidDelegation {
             blsPubKey,
             peerId,
             signature,
-            address(this).balance
+            getStake()
+//TODO: remove
+//            address(this).balance
         );
-        // TODO: replace address(this).balance everywhere with getRewards()?
 
         // the owner's deposit must also be recorded as staking otherwise
         // the owner would not benefit from the rewards accrued by the deposit
@@ -192,8 +192,6 @@ contract NonLiquidDelegationV2 is BaseDelegation, INonLiquidDelegation {
             newRewards = (int256(getRewards()) - $.totalRewards).toUint256();
         }
         $.totalRewards = int256(getRewards());
-        //$.stakings.push(Staking(uint256(amount), uint256(value), newRewards));
-        //TODO: just for testing purposes, otherwise replace with the previous line
         $.stakings.push(Staking(staker, uint256(amount), uint256(value), newRewards));
         $.stakingIndices[staker].push(uint64($.stakings.length - 1));
     }

--- a/test/BaseDelegation.t.sol
+++ b/test/BaseDelegation.t.sol
@@ -110,10 +110,10 @@ abstract contract BaseDelegationTest is Test {
             delegation.DEPOSIT_CONTRACT(),
             address(new Deposit()).code
         );
-        vm.store(delegation.DEPOSIT_CONTRACT(), bytes32(uint256(0x958a6cf6390bd7165e3519675caa670ab90f0161508a9ee714d3db7edc50740b)), bytes32(uint256(block.number / 10)));
-        vm.store(delegation.DEPOSIT_CONTRACT(), bytes32(uint256(0x958a6cf6390bd7165e3519675caa670ab90f0161508a9ee714d3db7edc50740c)), bytes32(uint256(10_000_000 ether)));
-        vm.store(delegation.DEPOSIT_CONTRACT(), bytes32(uint256(0x958a6cf6390bd7165e3519675caa670ab90f0161508a9ee714d3db7edc50740d)), bytes32(uint256(256)));
-        vm.store(delegation.DEPOSIT_CONTRACT(), bytes32(uint256(0x958a6cf6390bd7165e3519675caa670ab90f0161508a9ee714d3db7edc50740e)), bytes32(uint256(10)));
+        vm.store(delegation.DEPOSIT_CONTRACT(), bytes32(uint256(0x958a6cf6390bd7165e3519675caa670ab90f0161508a9ee714d3db7edc50740a)), bytes32(uint256(block.number / 10)));
+        vm.store(delegation.DEPOSIT_CONTRACT(), bytes32(uint256(0x958a6cf6390bd7165e3519675caa670ab90f0161508a9ee714d3db7edc50740b)), bytes32(uint256(10_000_000 ether)));
+        vm.store(delegation.DEPOSIT_CONTRACT(), bytes32(uint256(0x958a6cf6390bd7165e3519675caa670ab90f0161508a9ee714d3db7edc50740c)), bytes32(uint256(256)));
+        vm.store(delegation.DEPOSIT_CONTRACT(), bytes32(uint256(0x958a6cf6390bd7165e3519675caa670ab90f0161508a9ee714d3db7edc50740d)), bytes32(uint256(10)));
         /*
         console.log("Deposit.minimimStake() =", Deposit(delegation.DEPOSIT_CONTRACT()).minimumStake());
         console.log("Deposit.maximumStakers() =", Deposit(delegation.DEPOSIT_CONTRACT()).maximumStakers());
@@ -213,19 +213,12 @@ abstract contract BaseDelegationTest is Test {
         vm.stopPrank();
     }
 
-    function leave(
-        BaseDelegation delegation,
-        address controlAddress,
+    function validator(
         uint8 validatorId
-    ) internal {
-        vm.startPrank(controlAddress);
-        bytes memory blsPubKey = bytes(hex"92fbe50544dce63cfdcc88301d7412f0edea024c91ae5d6a04c7cd3819edfc1b9d75d9121080af12e00f054d221f876c");
+    ) internal view returns(bytes memory blsPubKey) {
+        blsPubKey = bytes(hex"92fbe50544dce63cfdcc88301d7412f0edea024c91ae5d6a04c7cd3819edfc1b9d75d9121080af12e00f054d221f876c");
         blsPubKey[47] = currentDeploymentId;
         blsPubKey[0] = bytes1(validatorId);
-        delegation.leave(
-            blsPubKey
-        );
-        vm.stopPrank();
     }
 
     function claimsAfterManyUnstakings(BaseDelegation delegation, uint64 steps) internal {

--- a/test/BaseDelegation.t.sol
+++ b/test/BaseDelegation.t.sol
@@ -20,7 +20,7 @@ abstract contract BaseDelegationTest is Test {
     bytes internal reinitializerCall;
     bytes1 internal currentDeploymentId;
     address internal owner = 0x15fc323DFE5D5DCfbeEdc25CEcbf57f676634d77;
-    address[4] internal stakers = [
+    address[] internal stakers = [
         0xd819fFcE7A58b1E835c25617Db7b46a00888B013,
         0x092E5E57955437876dA9Df998C96e2BE19341670,
         0xeA78aAE5Be606D2D152F00760662ac321aB8F017,

--- a/test/BaseDelegation.t.sol
+++ b/test/BaseDelegation.t.sol
@@ -6,7 +6,7 @@ import {BlsVerifyPrecompile} from "test/BlsVerifyPrecompile.t.sol";
 import {BaseDelegation} from "src/BaseDelegation.sol";
 import {WithdrawalQueue} from "src/WithdrawalQueue.sol";
 import {IDelegation} from "src/IDelegation.sol";
-import {Deposit} from "@zilliqa/zq2/deposit_v3.sol";
+import {Deposit} from "@zilliqa/zq2/deposit_v4.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {Test} from "forge-std/Test.sol";
 import {console} from "forge-std/console.sol";
@@ -18,7 +18,8 @@ abstract contract BaseDelegationTest is Test {
     bytes internal initializerCall;
     address payable internal newImplementation;
     bytes internal reinitializerCall;
-    address internal owner;
+    bytes1 internal currentDeploymentId;
+    address internal owner = 0x15fc323DFE5D5DCfbeEdc25CEcbf57f676634d77;
     address[4] internal stakers = [
         0xd819fFcE7A58b1E835c25617Db7b46a00888B013,
         0x092E5E57955437876dA9Df998C96e2BE19341670,
@@ -27,8 +28,6 @@ abstract contract BaseDelegationTest is Test {
     ];
 
     constructor() {
-        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
-        owner = vm.addr(deployerPrivateKey);
         for (uint256 i = 0; i < stakers.length; i++)
             assertNotEq(owner, stakers[i], "owner and staker must be different");
         //console.log("Signer is %s", owner);
@@ -37,6 +36,11 @@ abstract contract BaseDelegationTest is Test {
     function storeDelegation() internal virtual;
 
     function setUp() public {
+        deploy();
+        deploy();
+    }
+
+    function deploy() internal {
         vm.chainId(33469);
         vm.deal(owner, 100_000 ether);
         vm.startPrank(owner);
@@ -121,55 +125,17 @@ abstract contract BaseDelegationTest is Test {
         vm.stopPrank();
     }
 
-    enum DepositMode {DepositThenStake, StakeThenDeposit, DepositThenMigrate}
-
-    function migrate(
-        BaseDelegation delegation,
-        uint256 depositAmount
-    ) internal {
-        vm.deal(owner, owner.balance + depositAmount);
-        vm.startPrank(owner);
-
-        Deposit(delegation.DEPOSIT_CONTRACT()).deposit{
-            value: depositAmount
-        }(
-            bytes(hex"92fbe50544dce63cfdcc88301d7412f0edea024c91ae5d6a04c7cd3819edfc1b9d75d9121080af12e00f054d221f876c"),
-            bytes(hex"002408011220d5ed74b09dcbe84d3b32a56c01ab721cf82809848b6604535212a219d35c412f"),
-            bytes(hex"b14832a866a49ddf8a3104f8ee379d29c136f29aeb8fccec9d7fb17180b99e8ed29bee2ada5ce390cb704bc6fd7f5ce814f914498376c4b8bc14841a57ae22279769ec8614e2673ba7f36edc5a4bf5733aa9d70af626279ee2b2cde939b4bd8a"),
-            address(0x0),
-            address(0x0)
-        );
-
-        Deposit(delegation.DEPOSIT_CONTRACT()).setControlAddress(
-            bytes(hex"92fbe50544dce63cfdcc88301d7412f0edea024c91ae5d6a04c7cd3819edfc1b9d75d9121080af12e00f054d221f876c"),
-            address(delegation)
-        );
-
-        delegation.migrate(
-            bytes(hex"92fbe50544dce63cfdcc88301d7412f0edea024c91ae5d6a04c7cd3819edfc1b9d75d9121080af12e00f054d221f876c")
-        );
-
-        vm.stopPrank();
-    }
+    enum DepositMode {Bootstrapping, Fundraising, Transforming}
 
     function deposit(
         BaseDelegation delegation,
         uint256 depositAmount,
-        bool initialDeposit
+        DepositMode mode
     ) internal {
-        if (initialDeposit) {
-            vm.deal(owner, owner.balance + depositAmount);
-            vm.startPrank(owner);
-
-            delegation.depositFirst{
-                value: depositAmount
-            }(
-                bytes(hex"92fbe50544dce63cfdcc88301d7412f0edea024c91ae5d6a04c7cd3819edfc1b9d75d9121080af12e00f054d221f876c"),
-                bytes(hex"002408011220d5ed74b09dcbe84d3b32a56c01ab721cf82809848b6604535212a219d35c412f"),
-                bytes(hex"b14832a866a49ddf8a3104f8ee379d29c136f29aeb8fccec9d7fb17180b99e8ed29bee2ada5ce390cb704bc6fd7f5ce814f914498376c4b8bc14841a57ae22279769ec8614e2673ba7f36edc5a4bf5733aa9d70af626279ee2b2cde939b4bd8a")
-            );
-        } else {
-            uint256 preStaked = depositAmount / 10;
+        bytes memory blsPubKey;
+        currentDeploymentId = bytes1(uint8(currentDeploymentId) + 1);
+        uint256 preStaked = (mode == DepositMode.Fundraising) ? depositAmount / 10 : 0;
+        if (mode == DepositMode.Fundraising)
             for (uint256 i = 1; i <= 2; i++) {
                 vm.deal(stakers[i], stakers[i].balance + preStaked);
                 vm.startPrank(stakers[i]);
@@ -191,26 +157,82 @@ abstract contract BaseDelegationTest is Test {
                 vm.stopPrank();
             }
 
-            vm.deal(owner, owner.balance + depositAmount - 2 * preStaked);
+        if (mode == DepositMode.Fundraising || mode == DepositMode.Bootstrapping) {
+            vm.deal(owner, owner.balance + depositAmount - (mode == DepositMode.Fundraising ? 2 : 0) * preStaked);
             vm.startPrank(owner);
-            delegation.depositLater{
-                value: depositAmount - 2 * preStaked
+            blsPubKey = bytes(hex"01fbe50544dce63cfdcc88301d7412f0edea024c91ae5d6a04c7cd3819edfc1b9d75d9121080af12e00f054d221f876c");
+            blsPubKey[47] = currentDeploymentId;
+            delegation.deposit{
+                value: depositAmount - (mode == DepositMode.Fundraising ? 2 : 0) * preStaked
             }(
-                bytes(hex"92fbe50544dce63cfdcc88301d7412f0edea024c91ae5d6a04c7cd3819edfc1b9d75d9121080af12e00f054d221f876c"),
+                blsPubKey,
                 bytes(hex"002408011220d5ed74b09dcbe84d3b32a56c01ab721cf82809848b6604535212a219d35c412f"),
                 bytes(hex"b14832a866a49ddf8a3104f8ee379d29c136f29aeb8fccec9d7fb17180b99e8ed29bee2ada5ce390cb704bc6fd7f5ce814f914498376c4b8bc14841a57ae22279769ec8614e2673ba7f36edc5a4bf5733aa9d70af626279ee2b2cde939b4bd8a")
             );
             vm.stopPrank();
+
+            // wait 2 epochs for the change to the deposit to take affect
+            vm.roll(block.number + Deposit(delegation.DEPOSIT_CONTRACT()).blocksPerEpoch() * 2);
         }
-        // wait 2 epochs for the change to the deposit to take affect
-        vm.roll(block.number + Deposit(delegation.DEPOSIT_CONTRACT()).blocksPerEpoch() * 2);
+
+        if (mode == DepositMode.Transforming)
+            join(delegation, depositAmount, owner, 1);
+    }
+
+    function join(
+        BaseDelegation delegation,
+        uint256 depositAmount,
+        address controlAddress,
+        uint8 validatorId
+    ) internal {
+        vm.deal(controlAddress, controlAddress.balance + depositAmount);
+        vm.startPrank(controlAddress);
+        bytes memory blsPubKey = bytes(hex"92fbe50544dce63cfdcc88301d7412f0edea024c91ae5d6a04c7cd3819edfc1b9d75d9121080af12e00f054d221f876c");
+        blsPubKey[47] = currentDeploymentId;
+        blsPubKey[0] = bytes1(validatorId);
+        Deposit(delegation.DEPOSIT_CONTRACT()).deposit{
+            value: depositAmount
+        }(
+            blsPubKey,
+            bytes(hex"002408011220d5ed74b09dcbe84d3b32a56c01ab721cf82809848b6604535212a219d35c412f"),
+            bytes(hex"b14832a866a49ddf8a3104f8ee379d29c136f29aeb8fccec9d7fb17180b99e8ed29bee2ada5ce390cb704bc6fd7f5ce814f914498376c4b8bc14841a57ae22279769ec8614e2673ba7f36edc5a4bf5733aa9d70af626279ee2b2cde939b4bd8a"),
+            address(0x0),
+            address(0x0)
+        );
+        Deposit(delegation.DEPOSIT_CONTRACT()).setControlAddress(
+            blsPubKey,
+            address(delegation)
+        );
+        vm.stopPrank();
+
+        vm.startPrank(owner);
+        delegation.join(
+            blsPubKey,
+            controlAddress
+        );
+        vm.stopPrank();
+    }
+
+    function leave(
+        BaseDelegation delegation,
+        address controlAddress,
+        uint8 validatorId
+    ) internal {
+        vm.startPrank(controlAddress);
+        bytes memory blsPubKey = bytes(hex"92fbe50544dce63cfdcc88301d7412f0edea024c91ae5d6a04c7cd3819edfc1b9d75d9121080af12e00f054d221f876c");
+        blsPubKey[47] = currentDeploymentId;
+        blsPubKey[0] = bytes1(validatorId);
+        delegation.leave(
+            blsPubKey
+        );
+        vm.stopPrank();
     }
 
     function claimsAfterManyUnstakings(BaseDelegation delegation, uint64 steps) internal {
         uint256 i;
         uint256 x;
 
-        deposit(BaseDelegation(delegation), 10_000_000 ether, true);
+        deposit(BaseDelegation(delegation), 10_000_000 ether, DepositMode.Bootstrapping);
 
         // wait 2 epochs for the change to the deposit to take affect
         vm.roll(block.number + Deposit(delegation.DEPOSIT_CONTRACT()).blocksPerEpoch() * 2);

--- a/test/BaseDelegation.t.sol
+++ b/test/BaseDelegation.t.sol
@@ -110,10 +110,10 @@ abstract contract BaseDelegationTest is Test {
             delegation.DEPOSIT_CONTRACT(),
             address(new Deposit()).code
         );
-        vm.store(delegation.DEPOSIT_CONTRACT(), bytes32(uint256(0x958a6cf6390bd7165e3519675caa670ab90f0161508a9ee714d3db7edc50740a)), bytes32(uint256(block.number / 10)));
-        vm.store(delegation.DEPOSIT_CONTRACT(), bytes32(uint256(0x958a6cf6390bd7165e3519675caa670ab90f0161508a9ee714d3db7edc50740b)), bytes32(uint256(10_000_000 ether)));
-        vm.store(delegation.DEPOSIT_CONTRACT(), bytes32(uint256(0x958a6cf6390bd7165e3519675caa670ab90f0161508a9ee714d3db7edc50740c)), bytes32(uint256(256)));
-        vm.store(delegation.DEPOSIT_CONTRACT(), bytes32(uint256(0x958a6cf6390bd7165e3519675caa670ab90f0161508a9ee714d3db7edc50740d)), bytes32(uint256(10)));
+        vm.store(delegation.DEPOSIT_CONTRACT(), bytes32(uint256(0x958a6cf6390bd7165e3519675caa670ab90f0161508a9ee714d3db7edc50740b)), bytes32(uint256(block.number / 10)));
+        vm.store(delegation.DEPOSIT_CONTRACT(), bytes32(uint256(0x958a6cf6390bd7165e3519675caa670ab90f0161508a9ee714d3db7edc50740c)), bytes32(uint256(10_000_000 ether)));
+        vm.store(delegation.DEPOSIT_CONTRACT(), bytes32(uint256(0x958a6cf6390bd7165e3519675caa670ab90f0161508a9ee714d3db7edc50740d)), bytes32(uint256(256)));
+        vm.store(delegation.DEPOSIT_CONTRACT(), bytes32(uint256(0x958a6cf6390bd7165e3519675caa670ab90f0161508a9ee714d3db7edc50740e)), bytes32(uint256(10)));
         /*
         console.log("Deposit.minimimStake() =", Deposit(delegation.DEPOSIT_CONTRACT()).minimumStake());
         console.log("Deposit.maximumStakers() =", Deposit(delegation.DEPOSIT_CONTRACT()).maximumStakers());

--- a/test/LiquidDelegation.t.sol
+++ b/test/LiquidDelegation.t.sol
@@ -932,7 +932,7 @@ contract LiquidDelegationTest is BaseDelegationTest {
         assertEq(lstPrice1, lstPrice2, "LST price mismatch");
     }
 
-    function test_Bootstrapping_Compare1Vs9Delegations() public {
+    function test_Bootstrapping_CompareOneVsMoreDelegations() public {
         uint256 depositAmount = 10_000_000 ether;
         uint256 totalDeposit = 5_200_000_000 ether;
         uint256 delegatedAmount = 100 ether;
@@ -1046,7 +1046,7 @@ contract LiquidDelegationTest is BaseDelegationTest {
         assertEq(unstakedAmount1, unstakedAmount2, "unstaked amount mismatch");
     }
 
-    function test_Bootstrapping_CompareJoin3AndLeave3() public {
+    function test_Bootstrapping_CompareJoin3MoreAndLeave3() public {
         uint256 depositAmount = 10_000_000 ether;
         uint256 totalDeposit = 5_200_000_000 ether;
         uint256 delegatedAmount = 100 ether;
@@ -1092,7 +1092,7 @@ contract LiquidDelegationTest is BaseDelegationTest {
 
     // Additional test cases start here
 
-    function test_LeaveAfterPriceChange() public {
+    function test_LeaveAfterOthersStaked() public {
         uint256 depositAmount = 10_000_000 ether;
         uint256 totalDeposit = 5_200_000_000 ether;
         uint256 delegatedAmount = 100 ether;
@@ -1124,10 +1124,10 @@ contract LiquidDelegationTest is BaseDelegationTest {
         leave(BaseDelegation(delegation), makeAddr("2"), 2);
         assertEq(delegation.validators().length, 1, "validator leaving failed");
         assertLt(lstPrice1, lstPrice2, "LST price should increase");
-        assertGt(unstakedAmount1, unstakedAmount2, "unstaked should decrease");
+        assertGt(unstakedAmount1, unstakedAmount2, "unstaked amount should decrease");
     }
 
-    function test_JoinAndUnstake() public {
+    function test_UnstakeNotTooMuch() public {
         uint256 depositAmount = 10_000_000 ether;
         deposit(BaseDelegation(delegation), 2 * depositAmount, DepositMode.Bootstrapping);
         join(BaseDelegation(delegation), 2 * depositAmount, makeAddr("2"), 2);
@@ -1141,7 +1141,7 @@ contract LiquidDelegationTest is BaseDelegationTest {
         vm.stopPrank();
     }
 
-    function testFail_JoinAndForceToLeave() public {
+    function testFail_UnstakeTooMuch() public {
         uint256 depositAmount = 10_000_000 ether;
         deposit(BaseDelegation(delegation), 2 * depositAmount, DepositMode.Bootstrapping);
         join(BaseDelegation(delegation), 2 * depositAmount, makeAddr("2"), 2);

--- a/test/LiquidDelegation.t.sol
+++ b/test/LiquidDelegation.t.sol
@@ -207,7 +207,7 @@ contract LiquidDelegationTest is BaseDelegationTest {
         uint256[2] memory stakerLST = [lst.balanceOf(stakers[0]), 0];
         ownerZIL[0] = delegation.owner().balance;
 
-        uint256 shares = mode != DepositMode.StakeThenDeposit ? lst.balanceOf(stakers[0]) : lst.balanceOf(stakers[0]) - depositAmount;
+        uint256 shares = mode != DepositMode.StakeThenDeposit ? lst.balanceOf(stakers[0]) : lst.balanceOf(stakers[0]) - depositAmount / 10;
         assertEq(totalShares, shares, "staked shares balance mismatch");
 
         delegation.unstake(

--- a/test/NonLiquidDelegation.t.sol
+++ b/test/NonLiquidDelegation.t.sol
@@ -42,7 +42,7 @@ contract NonLiquidDelegationTest is BaseDelegationTest {
         for (uint256 i = 0; i < stakers.length; i++)
             if (stakers[i] == a)
                 return i;
-        revert("staker not found");
+        revert(string.concat("staker not found ", Strings.toHexString(a)));
     }  
 
     function snapshot(string memory s, uint256 i, uint256 x) internal view returns(uint256 calculatedRewards) {
@@ -100,7 +100,7 @@ contract NonLiquidDelegationTest is BaseDelegationTest {
         console.log("allWithdrawnRewards = %s   withdrawnAfterLastStaking = %s", allWithdrawnRewards, withdrawnAfterLastStaking);
     } 
 
-    function run (
+    function run(
         bytes memory _stakerIndicesBeforeWithdrawals,
         // each element in the interval (-100, 100)
         // if element negative, unstake -depositAmount * element / 10
@@ -123,14 +123,15 @@ contract NonLiquidDelegationTest is BaseDelegationTest {
         int256[] memory relativeAmountsAfterWithdrawals = abi.decode(_relativeAmountsAfterWithdrawals, (int256[]));
         require(stakerIndicesAfterWithdrawals.length == relativeAmountsAfterWithdrawals.length, "array length mismatch");
 
+//TODO: remove
+//        if (mode != DepositMode.StakeThenDeposit)
+        // otherwise findStaker() doesn't find the staker and reverts
+        stakers[0] = owner;
+
         if (mode == DepositMode.DepositThenMigrate)
             migrate(BaseDelegation(delegation), depositAmount);
         else
             deposit(BaseDelegation(delegation), depositAmount, mode == DepositMode.DepositThenStake);
-
-        if (mode != DepositMode.StakeThenDeposit)
-            // otherwise snapshot() doesn't find the staker and reverts
-            stakers[0] = owner;
 
         for (uint256 i = 0; i < stakers.length; i++) {
             vm.deal(stakers[i], 10 * depositAmount);
@@ -481,7 +482,7 @@ contract NonLiquidDelegationTest is BaseDelegationTest {
         vm.roll(block.number + Deposit(delegation.DEPOSIT_CONTRACT()).blocksPerEpoch() * 2);
 
         for (i = 0; i < 4; i++) {
-            vm.deal(stakers[i], 100_000 ether);
+            vm.deal(stakers[i], 200_000 ether);
             console.log("staker %s: %s", i+1, stakers[i]);
         }
 
@@ -489,7 +490,7 @@ contract NonLiquidDelegationTest is BaseDelegationTest {
 
         // rewards accrued so far
         vm.deal(address(delegation), 50_000 ether);
-        x = 50;
+        x = 100;
         for (uint256 j = 0; j < steps / 8; j++) {
             for (i = 1; i <= 4; i++) {
                 vm.startPrank(stakers[i-1]);
@@ -603,7 +604,7 @@ contract NonLiquidDelegationTest is BaseDelegationTest {
 
         // rewards accrued so far
         vm.deal(address(delegation), 50_000 ether);
-        x = 50;
+        x = 100;
         i = 2;
         vm.startPrank(stakers[i-1]);
         vm.recordLogs();

--- a/test/NonLiquidDelegation.t.sol
+++ b/test/NonLiquidDelegation.t.sol
@@ -257,15 +257,15 @@ contract NonLiquidDelegationTest is BaseDelegationTest {
             }
     }
 
-    //TODO: add tests that compare scenarios
+//TODO: add tests that compare scenarios
 
 //TODO: add tests for joining and leaving of additional validators
 
-    //TODO: add test cases where stakers[0] == owner i.e. everything gets unstaked
+//TODO: add test cases where stakers[0] == owner i.e. everything gets unstaked
 
     // Test cases of depositing first and staking afterwards start here
 
-    function test_Bootstrapping_withdrawAllRewards() public {
+    function test_Bootstrapping_WithdrawAllRewards() public {
         uint256 depositAmount = 10_000_000 ether;
         deposit(BaseDelegation(delegation), depositAmount, DepositMode.Bootstrapping);
         run(
@@ -280,7 +280,7 @@ contract NonLiquidDelegationTest is BaseDelegationTest {
         );
     }
 
-    function test_Bootstrapping_withdraw1Plus0Rewards () public {
+    function test_Bootstrapping_Withdraw1Plus0Rewards () public {
         uint256 depositAmount = 10_000_000 ether;
         deposit(BaseDelegation(delegation), depositAmount, DepositMode.Bootstrapping);
         run(
@@ -295,7 +295,7 @@ contract NonLiquidDelegationTest is BaseDelegationTest {
         );
     }
 
-    function test_Bootstrapping_withdraw1Plus1Rewards () public {
+    function test_Bootstrapping_Withdraw1Plus1Rewards () public {
         uint256 depositAmount = 10_000_000 ether;
         deposit(BaseDelegation(delegation), depositAmount, DepositMode.Bootstrapping);
         run(
@@ -310,7 +310,7 @@ contract NonLiquidDelegationTest is BaseDelegationTest {
         );
     }
 
-    function test_Bootstrapping_withdraw1Plus2Rewards () public {
+    function test_Bootstrapping_Withdraw1Plus2Rewards () public {
         uint256 depositAmount = 10_000_000 ether;
         deposit(BaseDelegation(delegation), depositAmount, DepositMode.Bootstrapping);
         run(
@@ -325,7 +325,7 @@ contract NonLiquidDelegationTest is BaseDelegationTest {
         );
     }
 
-    function test_Bootstrapping_withdraw1Plus3Rewards () public {
+    function test_Bootstrapping_Withdraw1Plus3Rewards () public {
         uint256 depositAmount = 10_000_000 ether;
         deposit(BaseDelegation(delegation), depositAmount, DepositMode.Bootstrapping);
         run(
@@ -342,7 +342,7 @@ contract NonLiquidDelegationTest is BaseDelegationTest {
 
     // Test cases of turning a solo staker into a staking pool start here
 
-    function test_Transforming_withdrawAllRewards() public {
+    function test_Transforming_WithdrawAllRewards() public {
         uint256 depositAmount = 10_000_000 ether;
         deposit(BaseDelegation(delegation), depositAmount, DepositMode.Transforming);
         run(
@@ -357,7 +357,7 @@ contract NonLiquidDelegationTest is BaseDelegationTest {
         );
     }
 
-    function test_Transforming_withdraw1Plus0Rewards () public {
+    function test_Transforming_Withdraw1Plus0Rewards () public {
         uint256 depositAmount = 10_000_000 ether;
         deposit(BaseDelegation(delegation), depositAmount, DepositMode.Transforming);
         run(
@@ -372,7 +372,7 @@ contract NonLiquidDelegationTest is BaseDelegationTest {
         );
     }
 
-    function test_Transforming_withdraw1Plus1Rewards () public {
+    function test_Transforming_Withdraw1Plus1Rewards () public {
         uint256 depositAmount = 10_000_000 ether;
         deposit(BaseDelegation(delegation), depositAmount, DepositMode.Transforming);
         run(
@@ -387,7 +387,7 @@ contract NonLiquidDelegationTest is BaseDelegationTest {
         );
     }
 
-    function test_Transforming_withdraw1Plus2Rewards () public {
+    function test_Transforming_Withdraw1Plus2Rewards () public {
         uint256 depositAmount = 10_000_000 ether;
         deposit(BaseDelegation(delegation), depositAmount, DepositMode.Transforming);
         run(
@@ -402,7 +402,7 @@ contract NonLiquidDelegationTest is BaseDelegationTest {
         );
     }
 
-    function test_Transforming_withdraw1Plus3Rewards () public {
+    function test_Transforming_Withdraw1Plus3Rewards () public {
         uint256 depositAmount = 10_000_000 ether;
         deposit(BaseDelegation(delegation), depositAmount, DepositMode.Transforming);
         run(
@@ -419,7 +419,7 @@ contract NonLiquidDelegationTest is BaseDelegationTest {
 
     // Test cases of staking first and depositing later start here
 
-    function test_Fundraising_withdrawAllRewards() public {
+    function test_Fundraising_WithdrawAllRewards() public {
         uint256 depositAmount = 10_000_000 ether;
         deposit(BaseDelegation(delegation), depositAmount, DepositMode.Fundraising);
         run(
@@ -434,7 +434,7 @@ contract NonLiquidDelegationTest is BaseDelegationTest {
         );
     }
 
-    function test_Fundraising_withdraw1Plus0Rewards () public {
+    function test_Fundraising_Withdraw1Plus0Rewards () public {
         uint256 depositAmount = 10_000_000 ether;
         deposit(BaseDelegation(delegation), depositAmount, DepositMode.Fundraising);
         run(
@@ -449,7 +449,7 @@ contract NonLiquidDelegationTest is BaseDelegationTest {
         );
     }
 
-    function test_Fundraising_withdraw1Plus1Rewards () public {
+    function test_Fundraising_Withdraw1Plus1Rewards () public {
         uint256 depositAmount = 10_000_000 ether;
         deposit(BaseDelegation(delegation), depositAmount, DepositMode.Fundraising);
         run(
@@ -464,7 +464,7 @@ contract NonLiquidDelegationTest is BaseDelegationTest {
         );
     }
 
-    function test_Fundraising_withdraw1Plus2Rewards () public {
+    function test_Fundraising_Withdraw1Plus2Rewards () public {
         uint256 depositAmount = 10_000_000 ether;
         deposit(BaseDelegation(delegation), depositAmount, DepositMode.Fundraising);
         run(
@@ -479,7 +479,7 @@ contract NonLiquidDelegationTest is BaseDelegationTest {
         );
     }
 
-    function test_Fundraising_withdraw1Plus3Rewards_DelegatedDeposit () public {
+    function test_Fundraising_Withdraw1Plus3Rewards_DelegatedDeposit () public {
         uint256 depositAmount = 10_000_000 ether;
         deposit(BaseDelegation(delegation), depositAmount, DepositMode.Fundraising);
         run(
@@ -498,7 +498,7 @@ contract NonLiquidDelegationTest is BaseDelegationTest {
 
     // run with
     // forge test -vv --via-ir --gas-report --gas-limit 10000000000 --block-gas-limit 10000000000 --match-test AfterMany
-    function test_withdrawAfterManyStakings() public {
+    function test_WithdrawAfterManyStakings() public {
         uint256 i;
         uint256 x;
         uint64 steps = 11_000;
@@ -605,14 +605,14 @@ contract NonLiquidDelegationTest is BaseDelegationTest {
         vm.stopPrank();
     }
 
-    function test_claimsAfterManyUnstakings() public {
+    function test_ClaimsAfterManyUnstakings() public {
         claimsAfterManyUnstakings(
             NonLiquidDelegationV2(proxy), //delegation
             20 //steps
         );
     }
 
-    function test_rewardsAfterWithdrawalLessThanBeforeWithdrawal() public {
+    function test_RewardsAfterWithdrawalLessThanBeforeWithdrawal() public {
         uint256 i;
         uint256 x;
 
@@ -704,7 +704,7 @@ contract NonLiquidDelegationTest is BaseDelegationTest {
         vm.stopPrank();
     }
 
-    function test_Fundraising_withdrawAllRewardsThenNoMoreStakings() public {
+    function test_Fundraising_WithdrawAllRewardsThenNoMoreStakings() public {
         uint256 depositAmount = 10_000_000 ether;
         deposit(BaseDelegation(delegation), depositAmount, DepositMode.Fundraising);
         run(


### PR DESCRIPTION
Besides supporting multiple validators, ensure compatibility with `deposit_v4` and modify the versioning scheme of the delegation contracts to use semver.