### PR TITLE
Implement replacement of delegator address

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,7 +406,7 @@ event RewardPaid(address indexed delegator, uint256 reward);
 function getDelegatedAmount() external view returns(uint256 result);
 function getDelegatedTotal() external view returns(uint256 result);
 function setNewAddress(address to) external;
-function replaceAddress(address old) external;
+function replaceOldAddress(address old) external;
 function rewards() external view returns(uint256 total);
 function withdrawAllRewards() external returns(uint256 taxedRewards);
 function withdrawRewards(uint256 amount) external returns(uint256 taxedRewards);

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ You will see an output like this:
   Proxy deployed: 0x7A0b7e6D24eDe78260c9ddBD98e828B0e11A8EA2 
   Implementation deployed: 0x7C623e01c5ce2e313C223ef2aEc1Ae5C6d12D9DD
   Owner is 0x15fc323DFE5D5DCfbeEdc25CEcbf57f676634d77
-  Upgraded to version: 0.3.0
+  Upgraded to version: 0.3.5
 ```
 
 You will need the proxy address from the above output in all commands below. If you know the address of a proxy contract but don't know which variant of staking it supports, run
@@ -66,10 +66,10 @@ forge script script/Upgrade.s.sol --broadcast --legacy --sig "run(address payabl
 The output will look like this:
 ```
   Signer is 0x15fc323DFE5D5DCfbeEdc25CEcbf57f676634d77
-  Upgrading from version: 0.3.0
+  Upgrading from version: 0.3.4
   Owner is 0x15fc323DFE5D5DCfbeEdc25CEcbf57f676634d77
   New implementation deployed: 0x64Fa96a67910956141cc481a43f242C045c10165
-  Upgraded to version: 0.3.4
+  Upgraded to version: 0.3.5
 ```
 
 If you want to check the current version your contract was upgraded to, run
@@ -89,7 +89,7 @@ forge script script/Configure.s.sol --broadcast --legacy --sig "commissionRate(a
 
 The output will contain the following information:
 ```
-  Running version: 0.3.4
+  Running version: 0.3.5
   Commission rate: 0.0%
   New commission rate: 10.0%
 ```
@@ -116,7 +116,7 @@ forge script script/Configure.s.sol --broadcast --legacy --sig "commissionReceiv
 
 The output will contain the following information:
 ```
-  Running version: 0.3.4
+  Running version: 0.3.5
   Commission receiver: 0x15fc323DFE5D5DCfbeEdc25CEcbf57f676634d77
   New commission receiver: 0xeA78aAE5Be606D2D152F00760662ac321aB8F017
 ```
@@ -207,7 +207,7 @@ with the private key of delegator account. It's important to make sure the accou
 
 The output will look like this for liquid staking:
 ```
-  Running version: 0.3.4
+  Running version: 0.3.5
   Current stake: 10000000000000000000000000 wei
   Current rewards: 110314207650273223687 wei
   LST address: 0x9e5c257D1c6dF74EaA54e58CdccaCb924669dc83
@@ -216,7 +216,7 @@ The output will look like this for liquid staking:
 ```
 and like this for the non-liquid variant:
 ```
-  Running version: 0.3.4
+  Running version: 0.3.5
   Current stake: 10000000000000000000000000 wei
   Current rewards: 110314207650273223687 wei
   Staker balance before: 99899145245801454561224 wei
@@ -243,7 +243,7 @@ using the private key of an account that holds some LST in case of the liquid va
 
 The output will look like this for liquid staking:
 ```
-  Running version: 0.3.4
+  Running version: 0.3.5
   Current stake: 10000000000000000000000000 wei
   Current rewards: 331912568306010928520 wei
   LST address: 0x9e5c257D1c6dF74EaA54e58CdccaCb924669dc83
@@ -252,7 +252,7 @@ The output will look like this for liquid staking:
 ```
 and like this for the non-liquid variant:
 ```
-  Running version: 0.3.4
+  Running version: 0.3.5
   Current stake: 10000000000000000000000000 wei
   Current rewards: 331912568306010928520 wei
   Staker balance before: 99698814298179759361224 wei
@@ -267,7 +267,7 @@ with the private key of the account that unstaked in the previous step.
 
 The output will look like this:
 ```
-  Running version: 0.3.4
+  Running version: 0.3.5
   Staker balance before: 99698086421983460161224 wei
   Staker balance after: 99798095485861371162343 wei
 ```
@@ -405,6 +405,8 @@ event RewardPaid(address indexed delegator, uint256 reward);
 
 function getDelegatedAmount() external view returns(uint256 result);
 function getDelegatedTotal() external view returns(uint256 result);
+function setNewAddress(address to) external;
+function replaceAddress(address old) external;
 function rewards() external view returns(uint256 total);
 function withdrawAllRewards() external returns(uint256 taxedRewards);
 function withdrawRewards(uint256 amount) external returns(uint256 taxedRewards);

--- a/src/BaseDelegation.sol
+++ b/src/BaseDelegation.sol
@@ -57,7 +57,7 @@ abstract contract BaseDelegation is IDelegation, PausableUpgradeable, Ownable2St
     // contract file names remain the same across all versions
     // so that the upgrade script does not need to be modified
     // to import the new version each time there is one
-    uint64 internal immutable VERSION = encodeVersion(0, 3, 4);
+    uint64 internal immutable VERSION = encodeVersion(0, 3, 5);
 
     function version() public view returns(uint64) {
         return _getInitializedVersion();

--- a/src/NonLiquidDelegation.sol
+++ b/src/NonLiquidDelegation.sol
@@ -137,7 +137,7 @@ contract NonLiquidDelegation is BaseDelegation, INonLiquidDelegation {
         $.newAddress[_msgSender()] = to;
     }
 
-    function replaceAddress(address old) public {
+    function replaceOldAddress(address old) public {
         NonLiquidDelegationStorage storage $ = _getNonLiquidDelegationStorage();
         address sender = _msgSender();
         require($.newAddress[old] == sender, "must be called by the new address");

--- a/test/NonLiquidDelegation.t.sol
+++ b/test/NonLiquidDelegation.t.sol
@@ -1597,7 +1597,7 @@ contract NonLiquidDelegationTest is BaseDelegationTest {
                     vm.stopPrank();
                     vm.deal(stakers[i-1], stakers[i-1].balance + 200_000 ether);
                     vm.startPrank(stakers[i-1]);
-                    delegation.replaceAddress(old);
+                    delegation.replaceOldAddress(old);
                     vm.stopPrank();
                 }
             for (i = 1; i <= 4; i++) {

--- a/test/NonLiquidDelegation.t.sol
+++ b/test/NonLiquidDelegation.t.sol
@@ -1567,6 +1567,125 @@ contract NonLiquidDelegationTest is BaseDelegationTest {
         vm.stopPrank();
     }
 
+    // run with
+    // forge test -vv --via-ir --gas-report --gas-limit 10000000000 --block-gas-limit 10000000000 --match-test AfterMany
+    function test_ReplaceAndWithdrawAfterManyStakings() public {
+        uint256 i;
+        uint256 x;
+        uint64 steps = 11_000;
+
+        deposit(BaseDelegation(delegation), 10_000_000 ether, DepositMode.Bootstrapping);
+
+        // wait 2 epochs for the change to the deposit to take affect
+        vm.roll(block.number + Deposit(delegation.DEPOSIT_CONTRACT()).blocksPerEpoch() * 2);
+
+        for (i = 0; i < 4; i++) {
+            vm.deal(stakers[i], 200_000 ether);
+            console.log("staker %s: %s", i+1, stakers[i]);
+        }
+
+        // rewards accrued so far
+        vm.deal(address(delegation), 50_000 ether);
+        x = 100;
+        for (uint256 j = 0; j < steps / 8; j++) {
+            if (j == steps / 8 / 2)
+                for (i = 1; i <= 4; i++) {
+                    address old = stakers[i-1];
+                    vm.startPrank(old);
+                    stakers[i-1] = makeAddr(Strings.toString(i));
+                    delegation.setNewAddress(stakers[i-1]);
+                    vm.stopPrank();
+                    vm.deal(stakers[i-1], stakers[i-1].balance + 200_000 ether);
+                    vm.startPrank(stakers[i-1]);
+                    delegation.replaceAddress(old);
+                    vm.stopPrank();
+                }
+            for (i = 1; i <= 4; i++) {
+                vm.startPrank(stakers[i-1]);
+                vm.recordLogs();
+                vm.expectEmit(
+                    true,
+                    false,
+                    false,
+                    false,
+                    address(delegation)
+                );
+                emit IDelegation.Staked(
+                    stakers[i-1],
+                    x * 1 ether,
+                    ""
+                );
+                delegation.stake{value: x * 1 ether}();
+                // wait 2 epochs for the change to the deposit to take affect
+                vm.roll(block.number + Deposit(delegation.DEPOSIT_CONTRACT()).blocksPerEpoch() * 2);
+                //snapshot("staker %s staked %s", i, x);
+                vm.stopPrank();
+                vm.deal(address(delegation), address(delegation).balance + 10_000 ether);
+            }
+            for (i = 1; i <= 4; i++) {
+                vm.startPrank(stakers[i-1]);
+                vm.recordLogs();
+                vm.expectEmit(
+                    true,
+                    false,
+                    false,
+                    false,
+                    address(delegation)
+                );
+                emit IDelegation.Unstaked(
+                    stakers[i-1],
+                    x * 1 ether,
+                    ""
+                );
+                delegation.unstake(x * 1 ether);
+                // wait 2 epochs for the change to the deposit to take affect
+                vm.roll(block.number + Deposit(delegation.DEPOSIT_CONTRACT()).blocksPerEpoch() * 2);
+                //snapshot("staker %s unstaked %s", i, x);
+                vm.stopPrank();
+                vm.deal(address(delegation), address(delegation).balance + 10_000 ether);
+            }
+        }
+
+        i = 1;
+        vm.startPrank(stakers[i-1]);
+        //snapshot("staker %s withdrawing 1+%s times", i, steps);
+        //Console.log("staker balance: %s.%s%s", stakers[i-1].balance);
+        //uint256 rewards = delegation.rewards(steps);
+        uint256 rewards = delegation.rewards();
+        Console.log("staker rewards: %s.%s%s", rewards);
+        rewards = delegation.withdrawRewards(rewards, steps);
+        //rewards = delegation.withdrawAllRewards();
+        /*
+        rewards = delegation.withdrawRewards(1000000, 2000);
+        rewards += delegation.withdrawRewards(1000000, 2000);
+        rewards += delegation.withdrawRewards(1000000, 2000);
+        rewards += delegation.withdrawRewards(1000000, 2000);
+        //*/
+        Console.log("staker withdrew: %s.%s%s", rewards);
+        //Console.log("staker balance: %s.%s%s", stakers[i-1].balance);
+        vm.stopPrank();
+
+        vm.roll(block.number + WithdrawalQueue.unbondingPeriod());
+
+        i = 1;
+        vm.startPrank(stakers[i-1]);
+        vm.recordLogs();
+        vm.expectEmit(
+            true,
+            false,
+            false,
+            false,
+            address(delegation)
+        );
+        emit IDelegation.Claimed(
+            stakers[i-1],
+            steps / 8 * x * 1 ether,
+            ""
+        );
+        delegation.claim();
+        vm.stopPrank();
+    }
+
     function test_ClaimsAfterManyUnstakings() public {
         claimsAfterManyUnstakings(
             NonLiquidDelegation(proxy), //delegation


### PR DESCRIPTION
Allows a delegator to replace its address in two steps:
1. call `setNewAddress()` from the old address
2. call `replaceAddress()` from the new address