### PR TITLE
Instant unstaking before pool activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ You will see an output like this:
   Proxy deployed: 0x7A0b7e6D24eDe78260c9ddBD98e828B0e11A8EA2 
   Implementation deployed: 0x7C623e01c5ce2e313C223ef2aEc1Ae5C6d12D9DD
   Owner is 0x15fc323DFE5D5DCfbeEdc25CEcbf57f676634d77
-  Upgraded to version: 0.3.5
+  Upgraded to version: 0.3.6
 ```
 
 You will need the proxy address from the above output in all commands below. If you know the address of a proxy contract but don't know which variant of staking it supports, run
@@ -66,10 +66,10 @@ forge script script/Upgrade.s.sol --broadcast --legacy --sig "run(address payabl
 The output will look like this:
 ```
   Signer is 0x15fc323DFE5D5DCfbeEdc25CEcbf57f676634d77
-  Upgrading from version: 0.3.4
+  Upgrading from version: 0.3.5
   Owner is 0x15fc323DFE5D5DCfbeEdc25CEcbf57f676634d77
   New implementation deployed: 0x64Fa96a67910956141cc481a43f242C045c10165
-  Upgraded to version: 0.3.5
+  Upgraded to version: 0.3.6
 ```
 
 If you want to check the current version your contract was upgraded to, run
@@ -89,7 +89,7 @@ forge script script/Configure.s.sol --broadcast --legacy --sig "commissionRate(a
 
 The output will contain the following information:
 ```
-  Running version: 0.3.5
+  Running version: 0.3.6
   Commission rate: 0.0%
   New commission rate: 10.0%
 ```
@@ -116,7 +116,7 @@ forge script script/Configure.s.sol --broadcast --legacy --sig "commissionReceiv
 
 The output will contain the following information:
 ```
-  Running version: 0.3.5
+  Running version: 0.3.6
   Commission receiver: 0x15fc323DFE5D5DCfbeEdc25CEcbf57f676634d77
   New commission receiver: 0xeA78aAE5Be606D2D152F00760662ac321aB8F017
 ```
@@ -207,7 +207,7 @@ with the private key of delegator account. It's important to make sure the accou
 
 The output will look like this for liquid staking:
 ```
-  Running version: 0.3.5
+  Running version: 0.3.6
   Current stake: 10000000000000000000000000 wei
   Current rewards: 110314207650273223687 wei
   LST address: 0x9e5c257D1c6dF74EaA54e58CdccaCb924669dc83
@@ -216,7 +216,7 @@ The output will look like this for liquid staking:
 ```
 and like this for the non-liquid variant:
 ```
-  Running version: 0.3.5
+  Running version: 0.3.6
   Current stake: 10000000000000000000000000 wei
   Current rewards: 110314207650273223687 wei
   Staker balance before: 99899145245801454561224 wei
@@ -243,7 +243,7 @@ using the private key of an account that holds some LST in case of the liquid va
 
 The output will look like this for liquid staking:
 ```
-  Running version: 0.3.5
+  Running version: 0.3.6
   Current stake: 10000000000000000000000000 wei
   Current rewards: 331912568306010928520 wei
   LST address: 0x9e5c257D1c6dF74EaA54e58CdccaCb924669dc83
@@ -252,7 +252,7 @@ The output will look like this for liquid staking:
 ```
 and like this for the non-liquid variant:
 ```
-  Running version: 0.3.5
+  Running version: 0.3.6
   Current stake: 10000000000000000000000000 wei
   Current rewards: 331912568306010928520 wei
   Staker balance before: 99698814298179759361224 wei
@@ -267,7 +267,7 @@ with the private key of the account that unstaked in the previous step.
 
 The output will look like this:
 ```
-  Running version: 0.3.5
+  Running version: 0.3.6
   Staker balance before: 99698086421983460161224 wei
   Staker balance after: 99798095485861371162343 wei
 ```
@@ -387,6 +387,7 @@ function stake() external payable;
 function unstake(uint256) external returns(uint256 unstakedZil);
 function claim() external;
 
+function unbondingPeriod() external virtual view returns(uint256 numberOfBlocks);
 function getClaimable() external virtual view returns(uint256 total);
 function getPendingClaims() external virtual view returns(uint256[2][] memory blockNumbersAndAmounts);
 function getMinDelegation() external view returns(uint256 amount);

--- a/src/WithdrawalQueue.sol
+++ b/src/WithdrawalQueue.sol
@@ -3,8 +3,6 @@ pragma solidity ^0.8.26;
 
 library WithdrawalQueue {
 
-    address public constant DEPOSIT_CONTRACT = address(0x5A494C4445504F53495450524F5859);
-
     struct Item {
         uint256 blockNumber;
         uint256 amount;
@@ -16,16 +14,8 @@ library WithdrawalQueue {
         mapping(uint256 => Item) items;
     }
 
-    function unbondingPeriod() internal view returns(uint256) {
-        (bool success, bytes memory data) = DEPOSIT_CONTRACT.staticcall(
-            abi.encodeWithSignature("withdrawalPeriod()")
-        );
-        require(success, "unbonding period unknown");
-        return abi.decode(data, (uint256));
-    }
-
-    function enqueue(Fifo storage fifo, uint256 amount) internal {
-        fifo.items[fifo.last] = Item(block.number + unbondingPeriod(), amount);
+    function enqueue(Fifo storage fifo, uint256 amount, uint256 period) internal {
+        fifo.items[fifo.last] = Item(block.number + period, amount);
         fifo.last++;
     }
 

--- a/test/BaseDelegation.t.sol
+++ b/test/BaseDelegation.t.sol
@@ -269,7 +269,7 @@ abstract contract BaseDelegationTest is Test {
         }
         assertEq(delegation.getClaimable() + totalPending, totalUnstaked, "claims must match unstaked amount");
 
-        vm.roll(block.number + WithdrawalQueue.unbondingPeriod());
+        vm.roll(block.number + delegation.unbondingPeriod());
 
         console.log("--------------------------------------------------------------------");
         console.log("block number: %s", block.number);

--- a/test/LiquidDelegation.t.sol
+++ b/test/LiquidDelegation.t.sol
@@ -361,7 +361,7 @@ contract LiquidDelegationTest is BaseDelegationTest {
             1, // numberOfDelegations
             0, // rewardsAccruedAfterEach
             taxedRewardsAfterStaking + 365 * 24 * 51_000 ether * depositAmount / totalDeposit, // rewardsBeforeUnstaking
-            WithdrawalQueue.unbondingPeriod()
+            delegation.unbondingPeriod()
         );
     }
 
@@ -382,7 +382,7 @@ contract LiquidDelegationTest is BaseDelegationTest {
             1, // numberOfDelegations
             0, // rewardsAccruedAfterEach
             taxedRewardsAfterStaking + 365 * 24 * 51_000 ether * depositAmount / totalDeposit, // rewardsBeforeUnstaking
-            WithdrawalQueue.unbondingPeriod()
+            delegation.unbondingPeriod()
         );
     }
 
@@ -403,7 +403,7 @@ contract LiquidDelegationTest is BaseDelegationTest {
             1, // numberOfDelegations
             0, // rewardsAccruedAfterEach
             taxedRewardsAfterStaking + 365 * 24 * 51_000 ether * depositAmount / totalDeposit, // rewardsBeforeUnstaking
-            WithdrawalQueue.unbondingPeriod()
+            delegation.unbondingPeriod()
         );
     }
 
@@ -424,7 +424,7 @@ contract LiquidDelegationTest is BaseDelegationTest {
             1, // numberOfDelegations
             0, // rewardsAccruedAfterEach
             taxedRewardsAfterStaking + 365 * 24 * 51_000 ether * depositAmount / totalDeposit, // rewardsBeforeUnstaking
-            WithdrawalQueue.unbondingPeriod()
+            delegation.unbondingPeriod()
         );
     }
 
@@ -447,7 +447,7 @@ contract LiquidDelegationTest is BaseDelegationTest {
             1, // numberOfDelegations
             0, // rewardsAccruedAfterEach
             taxedRewardsAfterStaking + 365 * 24 * 51_000 ether * depositAmount / totalDeposit, // rewardsBeforeUnstaking
-            WithdrawalQueue.unbondingPeriod()
+            delegation.unbondingPeriod()
         );
     } 
 
@@ -468,7 +468,7 @@ contract LiquidDelegationTest is BaseDelegationTest {
             1, // numberOfDelegations
             0, // rewardsAccruedAfterEach
             taxedRewardsAfterStaking + 365 * 24 * 51_000 ether * depositAmount / totalDeposit, // rewardsBeforeUnstaking
-            WithdrawalQueue.unbondingPeriod()
+            delegation.unbondingPeriod()
         );
     } 
 
@@ -489,7 +489,7 @@ contract LiquidDelegationTest is BaseDelegationTest {
             1, // numberOfDelegations
             0, // rewardsAccruedAfterEach
             taxedRewardsAfterStaking + 365 * 24 * 51_000 ether * depositAmount / totalDeposit, // rewardsBeforeUnstaking
-            WithdrawalQueue.unbondingPeriod()
+            delegation.unbondingPeriod()
         );
     }
 
@@ -510,7 +510,7 @@ contract LiquidDelegationTest is BaseDelegationTest {
             1, // numberOfDelegations
             0, // rewardsAccruedAfterEach
             taxedRewardsAfterStaking + 365 * 24 * 51_000 ether * depositAmount / totalDeposit, // rewardsBeforeUnstaking
-            WithdrawalQueue.unbondingPeriod()
+            delegation.unbondingPeriod()
         );
     }
 
@@ -533,7 +533,7 @@ contract LiquidDelegationTest is BaseDelegationTest {
             1, // numberOfDelegations
             0, // rewardsAccruedAfterEach
             taxedRewardsAfterStaking + 365 * 24 * 51_000 ether * depositAmount / totalDeposit, // rewardsBeforeUnstaking
-            WithdrawalQueue.unbondingPeriod()
+            delegation.unbondingPeriod()
         );
     }
 
@@ -554,7 +554,7 @@ contract LiquidDelegationTest is BaseDelegationTest {
             1, // numberOfDelegations
             0, // rewardsAccruedAfterEach
             taxedRewardsAfterStaking + 365 * 24 * 51_000 ether * depositAmount / totalDeposit, // rewardsBeforeUnstaking
-            WithdrawalQueue.unbondingPeriod()
+            delegation.unbondingPeriod()
         );
     }
 
@@ -575,7 +575,7 @@ contract LiquidDelegationTest is BaseDelegationTest {
             1, // numberOfDelegations
             0, // rewardsAccruedAfterEach
             taxedRewardsAfterStaking + 365 * 24 * 51_000 ether * depositAmount / totalDeposit, // rewardsBeforeUnstaking
-            WithdrawalQueue.unbondingPeriod()
+            delegation.unbondingPeriod()
         );
     }
 
@@ -596,7 +596,7 @@ contract LiquidDelegationTest is BaseDelegationTest {
             1, // numberOfDelegations
             0, // rewardsAccruedAfterEach
             taxedRewardsAfterStaking + 365 * 24 * 51_000 ether * depositAmount / totalDeposit, // rewardsBeforeUnstaking
-            WithdrawalQueue.unbondingPeriod()
+            delegation.unbondingPeriod()
         );
     }
 
@@ -619,7 +619,7 @@ contract LiquidDelegationTest is BaseDelegationTest {
             1, // numberOfDelegations
             0, // rewardsAccruedAfterEach
             taxedRewardsAfterStaking + 365 * 24 * 51_000 ether * depositAmount / totalDeposit, // rewardsBeforeUnstaking
-            WithdrawalQueue.unbondingPeriod()
+            delegation.unbondingPeriod()
         );
     }
 
@@ -640,7 +640,7 @@ contract LiquidDelegationTest is BaseDelegationTest {
             1, // numberOfDelegations
             0, // rewardsAccruedAfterEach
             taxedRewardsAfterStaking + 365 * 24 * 51_000 ether * depositAmount / totalDeposit, // rewardsBeforeUnstaking
-            WithdrawalQueue.unbondingPeriod()
+            delegation.unbondingPeriod()
         );
     } 
 
@@ -661,7 +661,7 @@ contract LiquidDelegationTest is BaseDelegationTest {
             1, // numberOfDelegations
             0, // rewardsAccruedAfterEach
             taxedRewardsAfterStaking + 365 * 24 * 51_000 ether * depositAmount / totalDeposit, // rewardsBeforeUnstaking
-            WithdrawalQueue.unbondingPeriod()
+            delegation.unbondingPeriod()
         );
     }
 
@@ -682,7 +682,7 @@ contract LiquidDelegationTest is BaseDelegationTest {
             1, // numberOfDelegations
             0, // rewardsAccruedAfterEach
             taxedRewardsAfterStaking + 365 * 24 * 51_000 ether * depositAmount / totalDeposit, // rewardsBeforeUnstaking
-            WithdrawalQueue.unbondingPeriod()
+            delegation.unbondingPeriod()
         );
     } 
 
@@ -705,7 +705,7 @@ contract LiquidDelegationTest is BaseDelegationTest {
             1, // numberOfDelegations
             0, // rewardsAccruedAfterEach
             taxedRewardsAfterStaking, // rewardsBeforeUnstaking
-            WithdrawalQueue.unbondingPeriod()
+            delegation.unbondingPeriod()
         );
     }
 
@@ -726,7 +726,7 @@ contract LiquidDelegationTest is BaseDelegationTest {
             1, // numberOfDelegations
             0, // rewardsAccruedAfterEach
             taxedRewardsAfterStaking, // rewardsBeforeUnstaking
-            WithdrawalQueue.unbondingPeriod()
+            delegation.unbondingPeriod()
         );
     }
 
@@ -747,7 +747,7 @@ contract LiquidDelegationTest is BaseDelegationTest {
             1, // numberOfDelegations
             0, // rewardsAccruedAfterEach
             taxedRewardsAfterStaking, // rewardsBeforeUnstaking
-            WithdrawalQueue.unbondingPeriod()
+            delegation.unbondingPeriod()
         );
     }
 
@@ -768,7 +768,7 @@ contract LiquidDelegationTest is BaseDelegationTest {
             1, // numberOfDelegations
             0, // rewardsAccruedAfterEach
             taxedRewardsAfterStaking, // rewardsBeforeUnstaking
-            WithdrawalQueue.unbondingPeriod()
+            delegation.unbondingPeriod()
         );
     }
 
@@ -789,7 +789,7 @@ contract LiquidDelegationTest is BaseDelegationTest {
             1, // numberOfDelegations
             0, // rewardsAccruedAfterEach
             taxedRewardsAfterStaking, // rewardsBeforeUnstaking
-            WithdrawalQueue.unbondingPeriod()
+            delegation.unbondingPeriod()
         );
     }
 
@@ -810,7 +810,7 @@ contract LiquidDelegationTest is BaseDelegationTest {
             1, // numberOfDelegations
             0, // rewardsAccruedAfterEach
             taxedRewardsAfterStaking, // rewardsBeforeUnstaking
-            WithdrawalQueue.unbondingPeriod()
+            delegation.unbondingPeriod()
         );
     }
 
@@ -833,7 +833,7 @@ contract LiquidDelegationTest is BaseDelegationTest {
             1, // numberOfDelegations
             0, // rewardsAccruedAfterEach
             taxedRewardsAfterStaking + 365 * 24 * 51_000 ether * depositAmount / totalDeposit, // rewardsBeforeUnstaking
-            WithdrawalQueue.unbondingPeriod()
+            delegation.unbondingPeriod()
         );
         console.log("====================================================================");
         // delegation and lst point to the last element of delegations and lsts by default
@@ -850,7 +850,7 @@ contract LiquidDelegationTest is BaseDelegationTest {
             1, // numberOfDelegations
             0, // rewardsAccruedAfterEach
             taxedRewardsAfterStaking + 365 * 24 * 51_000 ether * 3 * depositAmount / totalDeposit, // rewardsBeforeUnstaking
-            WithdrawalQueue.unbondingPeriod()
+            delegation.unbondingPeriod()
         );
         assertApproxEqAbs(lstPrice1, lstPrice2, 1e11, "LST price mismatch");
     }     
@@ -872,7 +872,7 @@ contract LiquidDelegationTest is BaseDelegationTest {
             1, // numberOfDelegations
             0, // rewardsAccruedAfterEach
             taxedRewardsAfterStaking + 365 * 24 * 51_000 ether * depositAmount / totalDeposit, // rewardsBeforeUnstaking
-            WithdrawalQueue.unbondingPeriod()
+            delegation.unbondingPeriod()
         );
         console.log("====================================================================");
         // delegation and lst point to the last element of delegations and lsts by default
@@ -886,7 +886,7 @@ contract LiquidDelegationTest is BaseDelegationTest {
             1, // numberOfDelegations
             0, // rewardsAccruedAfterEach
             taxedRewardsAfterStaking + 365 * 24 * 51_000 ether * depositAmount / totalDeposit, // rewardsBeforeUnstaking
-            WithdrawalQueue.unbondingPeriod()
+            delegation.unbondingPeriod()
         );
         assertEq(lstPrice1, lstPrice2, "LST price mismatch");
     }
@@ -908,7 +908,7 @@ contract LiquidDelegationTest is BaseDelegationTest {
             1, // numberOfDelegations
             0, // rewardsAccruedAfterEach
             taxedRewardsAfterStaking + 365 * 24 * 51_000 ether * depositAmount / totalDeposit, // rewardsBeforeUnstaking
-            WithdrawalQueue.unbondingPeriod()
+            delegation.unbondingPeriod()
         );
         console.log("====================================================================");
         // delegation and lst point to the last element of delegations and lsts by default
@@ -922,7 +922,7 @@ contract LiquidDelegationTest is BaseDelegationTest {
             1, // numberOfDelegations
             0, // rewardsAccruedAfterEach
             taxedRewardsAfterStaking + 365 * 24 * 51_000 ether * depositAmount / totalDeposit, // rewardsBeforeUnstaking
-            WithdrawalQueue.unbondingPeriod()
+            delegation.unbondingPeriod()
         );
         assertEq(lstPrice1, lstPrice2, "LST price mismatch");
     }
@@ -944,7 +944,7 @@ contract LiquidDelegationTest is BaseDelegationTest {
             9, // numberOfDelegations
             0, // rewardsAccruedAfterEach
             taxedRewardsAfterStaking + 51_000 ether / uint256(60) * depositAmount / totalDeposit, // rewardsBeforeUnstaking
-            WithdrawalQueue.unbondingPeriod()
+            delegation.unbondingPeriod()
         );
         console.log("====================================================================");
         // delegation and lst point to the last element of delegations and lsts by default
@@ -958,7 +958,7 @@ contract LiquidDelegationTest is BaseDelegationTest {
             1, // numberOfDelegations
             0, // rewardsAccruedAfterEach
             taxedRewardsAfterStaking + 51_000 ether / uint256(60) * depositAmount / totalDeposit, // rewardsBeforeUnstaking
-            WithdrawalQueue.unbondingPeriod()
+            delegation.unbondingPeriod()
         );
         assertApproxEqAbs(unstakedAmount1, unstakedAmount2, 10, "unstaked amount not approximately same");
     }
@@ -980,7 +980,7 @@ contract LiquidDelegationTest is BaseDelegationTest {
             1, // numberOfDelegations
             0, // rewardsAccruedAfterEach
             taxedRewardsAfterStaking + 51_000 ether / uint256(60) * depositAmount / totalDeposit, // rewardsBeforeUnstaking
-            WithdrawalQueue.unbondingPeriod()
+            delegation.unbondingPeriod()
         );
         console.log("====================================================================");
         // delegation and lst point to the last element of delegations and lsts by default
@@ -998,7 +998,7 @@ contract LiquidDelegationTest is BaseDelegationTest {
             1, // numberOfDelegations
             0, // rewardsAccruedAfterEach
             taxedRewardsAfterStaking + 51_000 ether / uint256(60) * depositAmount / totalDeposit, // rewardsBeforeUnstaking
-            WithdrawalQueue.unbondingPeriod()
+            delegation.unbondingPeriod()
         );
         assertEq(lstPrice1, lstPrice2, "LST price mismatch");
         assertEq(unstakedAmount1, unstakedAmount2, "unstaked amount mismatch");
@@ -1021,7 +1021,7 @@ contract LiquidDelegationTest is BaseDelegationTest {
             1, // numberOfDelegations
             0, // rewardsAccruedAfterEach
             taxedRewardsAfterStaking + 51_000 ether / uint256(60) * depositAmount / totalDeposit, // rewardsBeforeUnstaking
-            WithdrawalQueue.unbondingPeriod()
+            delegation.unbondingPeriod()
         );
         console.log("====================================================================");
         // delegation and lst point to the last element of delegations and lsts by default
@@ -1039,7 +1039,7 @@ contract LiquidDelegationTest is BaseDelegationTest {
             1, // numberOfDelegations
             0, // rewardsAccruedAfterEach
             taxedRewardsAfterStaking + 51_000 ether / uint256(60) * depositAmount / totalDeposit, // rewardsBeforeUnstaking
-            WithdrawalQueue.unbondingPeriod()
+            delegation.unbondingPeriod()
         );
         assertEq(lstPrice1, lstPrice2, "LST price mismatch");
         assertEq(unstakedAmount1, unstakedAmount2, "unstaked amount mismatch");
@@ -1062,7 +1062,7 @@ contract LiquidDelegationTest is BaseDelegationTest {
             1, // numberOfDelegations
             0, // rewardsAccruedAfterEach
             taxedRewardsAfterStaking + 51_000 ether / uint256(60) * depositAmount / totalDeposit, // rewardsBeforeUnstaking
-            WithdrawalQueue.unbondingPeriod()
+            delegation.unbondingPeriod()
         );
         console.log("====================================================================");
         // delegation and lst point to the last element of delegations and lsts by default
@@ -1089,7 +1089,7 @@ contract LiquidDelegationTest is BaseDelegationTest {
             1, // numberOfDelegations
             0, // rewardsAccruedAfterEach
             taxedRewardsAfterStaking + 51_000 ether / uint256(60) * depositAmount / totalDeposit, // rewardsBeforeUnstaking
-            WithdrawalQueue.unbondingPeriod()
+            delegation.unbondingPeriod()
         );
         assertEq(lstPrice1, lstPrice2, "LST price mismatch");
         assertEq(unstakedAmount1, unstakedAmount2, "unstaked amount mismatch");
@@ -1114,7 +1114,7 @@ contract LiquidDelegationTest is BaseDelegationTest {
             1, // numberOfDelegations
             0, // rewardsAccruedAfterEach
             taxedRewardsAfterStaking + 51_000 ether / uint256(60) * depositAmount / totalDeposit, // rewardsBeforeUnstaking
-            WithdrawalQueue.unbondingPeriod()
+            delegation.unbondingPeriod()
         );
         join(BaseDelegation(delegation), depositAmount, makeAddr("2"), 2);
         (, , , , , , , , uint256 lstPrice2, , , , , , uint256 unstakedAmount2, ) = run(
@@ -1124,7 +1124,7 @@ contract LiquidDelegationTest is BaseDelegationTest {
             1, // numberOfDelegations
             0, // rewardsAccruedAfterEach
             taxedRewardsAfterStaking + 51_000 ether / uint256(60) * depositAmount / totalDeposit, // rewardsBeforeUnstaking
-            WithdrawalQueue.unbondingPeriod()
+            delegation.unbondingPeriod()
         );
         // stake and unstake to make pendingWithdrawals > 0 before leaving is initiated
         vm.startPrank(owner);
@@ -1143,7 +1143,7 @@ contract LiquidDelegationTest is BaseDelegationTest {
         vm.startPrank(stakers[4-1]);
         delegation.claim();
         assertTrue(delegation.pendingWithdrawals(validator(2)), "there should be pending withdrawals");
-        vm.roll(block.number + WithdrawalQueue.unbondingPeriod());
+        vm.roll(block.number + delegation.unbondingPeriod());
         vm.stopPrank();
         // stake and unstake but pendingWithdrawals remains 0 after leaving was initiated
         vm.startPrank(owner);
@@ -1163,7 +1163,7 @@ contract LiquidDelegationTest is BaseDelegationTest {
         // completion of leaving has to wait for the unbonding period
         delegation.completeLeaving(validator(2));
         assertEq(delegation.validators().length, 2, "validator leaving should not be completed yet");
-        vm.roll(block.number + WithdrawalQueue.unbondingPeriod());
+        vm.roll(block.number + delegation.unbondingPeriod());
         // completion of leaving is finally possible 
         delegation.completeLeaving(validator(2));
         assertEq(delegation.validators().length, 1, "validator leaving should be completed");
@@ -1189,7 +1189,7 @@ contract LiquidDelegationTest is BaseDelegationTest {
             1, // numberOfDelegations
             0, // rewardsAccruedAfterEach
             taxedRewardsAfterStaking + 51_000 ether / uint256(60) * depositAmount / totalDeposit, // rewardsBeforeUnstaking
-            WithdrawalQueue.unbondingPeriod()
+            delegation.unbondingPeriod()
         );
         join(BaseDelegation(delegation), depositAmount, makeAddr("2"), 2);
         (, , , , , , , , uint256 lstPrice2, , , , , , uint256 unstakedAmount2, ) = run(
@@ -1199,9 +1199,9 @@ contract LiquidDelegationTest is BaseDelegationTest {
             1, // numberOfDelegations
             0, // rewardsAccruedAfterEach
             taxedRewardsAfterStaking + 51_000 ether / uint256(60) * depositAmount / totalDeposit, // rewardsBeforeUnstaking
-            WithdrawalQueue.unbondingPeriod()
+            delegation.unbondingPeriod()
         );
-        vm.roll(block.number + WithdrawalQueue.unbondingPeriod());
+        vm.roll(block.number + delegation.unbondingPeriod());
         // if staker claims which calls withdrawDeposit() after the unbonding period, pendingWithdrawals will be 0
         vm.startPrank(stakers[4-1]);
         delegation.claim();
@@ -1213,7 +1213,7 @@ contract LiquidDelegationTest is BaseDelegationTest {
         // completion of leaving has to wait for the unbonding period
         delegation.completeLeaving(validator(2));
         assertEq(delegation.validators().length, 2, "validator leaving should not be completed yet");
-        vm.roll(block.number + WithdrawalQueue.unbondingPeriod());
+        vm.roll(block.number + delegation.unbondingPeriod());
         // completion of leaving is finally possible 
         delegation.completeLeaving(validator(2));
         assertEq(delegation.validators().length, 1, "validator leaving should be completed");
@@ -1239,7 +1239,7 @@ contract LiquidDelegationTest is BaseDelegationTest {
             1, // numberOfDelegations
             0, // rewardsAccruedAfterEach
             taxedRewardsAfterStaking + 51_000 ether / uint256(60) * depositAmount / totalDeposit, // rewardsBeforeUnstaking
-            WithdrawalQueue.unbondingPeriod()
+            delegation.unbondingPeriod()
         );
         join(BaseDelegation(delegation), depositAmount, makeAddr("2"), 2);
         (, , , , , , , , uint256 lstPrice2, , , , , , uint256 unstakedAmount2, ) = run(
@@ -1249,7 +1249,7 @@ contract LiquidDelegationTest is BaseDelegationTest {
             1, // numberOfDelegations
             0, // rewardsAccruedAfterEach
             taxedRewardsAfterStaking + 51_000 ether / uint256(60) * depositAmount / totalDeposit, // rewardsBeforeUnstaking
-            WithdrawalQueue.unbondingPeriod()
+            delegation.unbondingPeriod()
         );
         // stake and unstake to make pendingWithdrawals > 0 before leaving is initiated
         vm.startPrank(owner);
@@ -1268,7 +1268,7 @@ contract LiquidDelegationTest is BaseDelegationTest {
         vm.startPrank(stakers[4-1]);
         delegation.claim();
         assertTrue(delegation.pendingWithdrawals(validator(2)), "there should be pending withdrawals");
-        vm.roll(block.number + WithdrawalQueue.unbondingPeriod());
+        vm.roll(block.number + delegation.unbondingPeriod());
         vm.stopPrank();
         // stake and unstake but pendingWithdrawals remains 0 after leaving was initiated
         vm.startPrank(owner);
@@ -1303,7 +1303,7 @@ contract LiquidDelegationTest is BaseDelegationTest {
         uint256 controlAddressBalance = makeAddr("2").balance;
         delegation.claim();
         assertEq(makeAddr("2").balance - controlAddressBalance, 0, "control address should not be able to claim refund");
-        vm.roll(block.number + WithdrawalQueue.unbondingPeriod());
+        vm.roll(block.number + delegation.unbondingPeriod());
         // control address can claim the refund after the unbonding period 
         controlAddressBalance = makeAddr("2").balance;
         delegation.claim();
@@ -1330,7 +1330,7 @@ contract LiquidDelegationTest is BaseDelegationTest {
             1, // numberOfDelegations
             0, // rewardsAccruedAfterEach
             taxedRewardsAfterStaking + 51_000 ether / uint256(60) * depositAmount / totalDeposit, // rewardsBeforeUnstaking
-            WithdrawalQueue.unbondingPeriod()
+            delegation.unbondingPeriod()
         );
         join(BaseDelegation(delegation), depositAmount, makeAddr("2"), 2);
         (, , , , , , , , uint256 lstPrice2, , , , , , uint256 unstakedAmount2, ) = run(
@@ -1340,7 +1340,7 @@ contract LiquidDelegationTest is BaseDelegationTest {
             1, // numberOfDelegations
             0, // rewardsAccruedAfterEach
             taxedRewardsAfterStaking + 51_000 ether / uint256(60) * depositAmount / totalDeposit, // rewardsBeforeUnstaking
-            WithdrawalQueue.unbondingPeriod()
+            delegation.unbondingPeriod()
         );
         // control address stakes more than the validator's deposit
         vm.startPrank(makeAddr("2"));
@@ -1355,7 +1355,7 @@ contract LiquidDelegationTest is BaseDelegationTest {
         //TODO: calculate the exact amount without correction
         refund += 7_341_880;
         vm.stopPrank();
-        vm.roll(block.number + WithdrawalQueue.unbondingPeriod());
+        vm.roll(block.number + delegation.unbondingPeriod());
         // if staker claims which calls withdrawDeposit() after the unbonding period, pendingWithdrawals will be 0
         vm.startPrank(stakers[4-1]);
         delegation.claim();
@@ -1369,7 +1369,7 @@ contract LiquidDelegationTest is BaseDelegationTest {
         uint256 controlAddressBalance = makeAddr("2").balance;
         delegation.claim();
         assertEq(makeAddr("2").balance - controlAddressBalance, 0, "control address should not be able to claim refund");
-        vm.roll(block.number + WithdrawalQueue.unbondingPeriod());
+        vm.roll(block.number + delegation.unbondingPeriod());
         // control address can claim the refund after the unbonding period 
         controlAddressBalance = makeAddr("2").balance;
         delegation.claim();
@@ -1396,7 +1396,7 @@ contract LiquidDelegationTest is BaseDelegationTest {
             1, // numberOfDelegations
             0, // rewardsAccruedAfterEach
             taxedRewardsAfterStaking + 51_000 ether / uint256(60) * depositAmount / totalDeposit, // rewardsBeforeUnstaking
-            WithdrawalQueue.unbondingPeriod()
+            delegation.unbondingPeriod()
         );
         join(BaseDelegation(delegation), depositAmount, makeAddr("2"), 2);
         (, , , , , , , , uint256 lstPrice2, , , , , , uint256 unstakedAmount2, ) = run(
@@ -1406,7 +1406,7 @@ contract LiquidDelegationTest is BaseDelegationTest {
             1, // numberOfDelegations
             0, // rewardsAccruedAfterEach
             taxedRewardsAfterStaking + 51_000 ether / uint256(60) * depositAmount / totalDeposit, // rewardsBeforeUnstaking
-            WithdrawalQueue.unbondingPeriod()
+            delegation.unbondingPeriod()
         );
         // stake and unstake to make pendingWithdrawals > 0 before leaving is initiated
         vm.startPrank(owner);
@@ -1425,7 +1425,7 @@ contract LiquidDelegationTest is BaseDelegationTest {
         vm.startPrank(stakers[4-1]);
         delegation.claim();
         assertTrue(delegation.pendingWithdrawals(validator(2)), "there should be pending withdrawals");
-        vm.roll(block.number + WithdrawalQueue.unbondingPeriod());
+        vm.roll(block.number + delegation.unbondingPeriod());
         vm.stopPrank();
         // stake and unstake but pendingWithdrawals remains 0 after leaving was initiated
         vm.startPrank(owner);
@@ -1454,7 +1454,7 @@ contract LiquidDelegationTest is BaseDelegationTest {
         vm.startPrank(makeAddr("2"));
         delegation.leave(validator(2));
         assertEq(delegation.validators().length, 1, "validator leaving should be completed");
-        vm.roll(block.number + WithdrawalQueue.unbondingPeriod());
+        vm.roll(block.number + delegation.unbondingPeriod());
         // there is no refund to claim after the unbonding period 
         uint256 controlAddressBalance = makeAddr("2").balance;
         delegation.claim();
@@ -1481,7 +1481,7 @@ contract LiquidDelegationTest is BaseDelegationTest {
             1, // numberOfDelegations
             0, // rewardsAccruedAfterEach
             taxedRewardsAfterStaking + 51_000 ether / uint256(60) * depositAmount / totalDeposit, // rewardsBeforeUnstaking
-            WithdrawalQueue.unbondingPeriod()
+            delegation.unbondingPeriod()
         );
         join(BaseDelegation(delegation), depositAmount, makeAddr("2"), 2);
         (, , , , , , , , uint256 lstPrice2, , , , , , uint256 unstakedAmount2, ) = run(
@@ -1491,7 +1491,7 @@ contract LiquidDelegationTest is BaseDelegationTest {
             1, // numberOfDelegations
             0, // rewardsAccruedAfterEach
             taxedRewardsAfterStaking + 51_000 ether / uint256(60) * depositAmount / totalDeposit, // rewardsBeforeUnstaking
-            WithdrawalQueue.unbondingPeriod()
+            delegation.unbondingPeriod()
         );
         // control address stakes as much as the validator's deposit
         vm.startPrank(makeAddr("2"));
@@ -1504,7 +1504,7 @@ contract LiquidDelegationTest is BaseDelegationTest {
         vm.deal(makeAddr("2"), makeAddr("2").balance + amount);
         delegation.stake{value: amount}();
         vm.stopPrank();
-        vm.roll(block.number + WithdrawalQueue.unbondingPeriod());
+        vm.roll(block.number + delegation.unbondingPeriod());
         // if staker claims which calls withdrawDeposit() after the unbonding period, pendingWithdrawals will be 0
         vm.startPrank(stakers[4-1]);
         delegation.claim();
@@ -1514,7 +1514,7 @@ contract LiquidDelegationTest is BaseDelegationTest {
         vm.startPrank(makeAddr("2"));
         delegation.leave(validator(2));
         assertEq(delegation.validators().length, 1, "validator leaving should be completed");
-        vm.roll(block.number + WithdrawalQueue.unbondingPeriod());
+        vm.roll(block.number + delegation.unbondingPeriod());
         // there is no refund to claim after the unbonding period 
         uint256 controlAddressBalance = makeAddr("2").balance;
         delegation.claim();
@@ -1522,6 +1522,17 @@ contract LiquidDelegationTest is BaseDelegationTest {
         vm.stopPrank();
         assertLt(lstPrice1, lstPrice2, "LST price should increase");
         assertGt(unstakedAmount1, unstakedAmount2, "unstaked amount should decrease");
+    }
+
+    function test_InstantUnstakeBeforeActivation() public {
+        vm.deal(stakers[0], stakers[0].balance + 110 ether);
+        vm.startPrank(stakers[0]);
+        delegation.stake{value: 100 ether}();
+        uint256 stakerBalance = stakers[0].balance;
+        delegation.unstake(lst.balanceOf(stakers[0]));
+        delegation.claim();
+        assertEq(stakers[0].balance - stakerBalance, 100 ether, "balance must increase instantly");
+        vm.stopPrank();
     }
 
     function test_UnstakeNotTooMuch() public {
@@ -1626,7 +1637,7 @@ contract LiquidDelegationTest is BaseDelegationTest {
             // (numberOfDelegations - 1) * rewardsAccruedAfterEach <= rewardsBeforeUnstaking
             5 * 51_000 ether / uint256(3600) * depositAmount / totalDeposit, // rewardsAccruedAfterEach
             taxedRewardsAfterStaking + 51_000 ether / uint256(60) * depositAmount / totalDeposit, // rewardsBeforeUnstaking
-            WithdrawalQueue.unbondingPeriod()
+            delegation.unbondingPeriod()
         );
     }
 
@@ -1647,7 +1658,7 @@ contract LiquidDelegationTest is BaseDelegationTest {
             1, // numberOfDelegations
             0, // rewardsAccruedAfterEach
             taxedRewardsAfterStaking + 51_000 ether / uint256(60) * depositAmount / totalDeposit, // rewardsBeforeUnstaking
-            WithdrawalQueue.unbondingPeriod()
+            delegation.unbondingPeriod()
         );
     }
 

--- a/test/NonLiquidDelegation.t.sol
+++ b/test/NonLiquidDelegation.t.sol
@@ -905,7 +905,7 @@ contract NonLiquidDelegationTest is BaseDelegationTest {
         vm.startPrank(stakers[4-1]);
         delegation.claim();
         assertTrue(delegation.pendingWithdrawals(validator(2)), "there should be pending withdrawals");
-        vm.roll(block.number + WithdrawalQueue.unbondingPeriod());
+        vm.roll(block.number + delegation.unbondingPeriod());
         vm.stopPrank();
         // stake and unstake but pendingWithdrawals remains 0 after leaving was initiated
         vm.startPrank(owner);
@@ -924,7 +924,7 @@ contract NonLiquidDelegationTest is BaseDelegationTest {
         // completion of leaving has to wait for the unbonding period
         delegation.completeLeaving(validator(2));
         assertEq(delegation.validators().length, 2, "validator leaving should not be completed yet");
-        vm.roll(block.number + WithdrawalQueue.unbondingPeriod());
+        vm.roll(block.number + delegation.unbondingPeriod());
         // completion of leaving is finally possible 
         delegation.completeLeaving(validator(2));
         assertEq(delegation.validators().length, 1, "validator leaving should be completed");
@@ -982,7 +982,7 @@ contract NonLiquidDelegationTest is BaseDelegationTest {
             availableRewards2,
             withdrawnRewards2
         );
-        vm.roll(block.number + WithdrawalQueue.unbondingPeriod());
+        vm.roll(block.number + delegation.unbondingPeriod());
         // if staker claims which calls withdrawDeposit() after the unbonding period, pendingWithdrawals will be 0
         vm.startPrank(stakers[4-1]);
         delegation.claim();
@@ -994,7 +994,7 @@ contract NonLiquidDelegationTest is BaseDelegationTest {
         // completion of leaving has to wait for the unbonding period
         delegation.completeLeaving(validator(2));
         assertEq(delegation.validators().length, 2, "validator leaving should not be completed yet");
-        vm.roll(block.number + WithdrawalQueue.unbondingPeriod());
+        vm.roll(block.number + delegation.unbondingPeriod());
         // completion of leaving is finally possible 
         delegation.completeLeaving(validator(2));
         assertEq(delegation.validators().length, 1, "validator leaving should be completed");
@@ -1068,7 +1068,7 @@ contract NonLiquidDelegationTest is BaseDelegationTest {
         vm.startPrank(stakers[4-1]);
         delegation.claim();
         assertTrue(delegation.pendingWithdrawals(validator(2)), "there should be pending withdrawals");
-        vm.roll(block.number + WithdrawalQueue.unbondingPeriod());
+        vm.roll(block.number + delegation.unbondingPeriod());
         vm.stopPrank();
         // stake and unstake but pendingWithdrawals remains 0 after leaving was initiated
         vm.startPrank(owner);
@@ -1099,7 +1099,7 @@ contract NonLiquidDelegationTest is BaseDelegationTest {
         uint256 controlAddressBalance = makeAddr("2").balance;
         delegation.claim();
         assertEq(makeAddr("2").balance - controlAddressBalance, 0, "control address should not be able to claim refund");
-        vm.roll(block.number + WithdrawalQueue.unbondingPeriod());
+        vm.roll(block.number + delegation.unbondingPeriod());
         // control address can claim the refund after the unbonding period 
         controlAddressBalance = makeAddr("2").balance;
         delegation.claim();
@@ -1168,7 +1168,7 @@ contract NonLiquidDelegationTest is BaseDelegationTest {
         delegation.stake{value: amount}();
         uint256 refund = delegation.getDelegatedAmount() - delegation.getStake(validator(2));
         vm.stopPrank();
-        vm.roll(block.number + WithdrawalQueue.unbondingPeriod());
+        vm.roll(block.number + delegation.unbondingPeriod());
         // if staker claims which calls withdrawDeposit() after the unbonding period, pendingWithdrawals will be 0
         vm.startPrank(stakers[4-1]);
         delegation.claim();
@@ -1182,7 +1182,7 @@ contract NonLiquidDelegationTest is BaseDelegationTest {
         uint256 controlAddressBalance = makeAddr("2").balance;
         delegation.claim();
         assertEq(makeAddr("2").balance - controlAddressBalance, 0, "control address should not be able to claim refund");
-        vm.roll(block.number + WithdrawalQueue.unbondingPeriod());
+        vm.roll(block.number + delegation.unbondingPeriod());
         // control address can claim the refund after the unbonding period 
         controlAddressBalance = makeAddr("2").balance;
         delegation.claim();
@@ -1257,7 +1257,7 @@ contract NonLiquidDelegationTest is BaseDelegationTest {
         vm.startPrank(stakers[4-1]);
         delegation.claim();
         assertTrue(delegation.pendingWithdrawals(validator(2)), "there should be pending withdrawals");
-        vm.roll(block.number + WithdrawalQueue.unbondingPeriod());
+        vm.roll(block.number + delegation.unbondingPeriod());
         vm.stopPrank();
         // stake and unstake but pendingWithdrawals remains 0 after leaving was initiated
         vm.startPrank(owner);
@@ -1282,7 +1282,7 @@ contract NonLiquidDelegationTest is BaseDelegationTest {
         vm.startPrank(makeAddr("2"));
         delegation.leave(validator(2));
         assertEq(delegation.validators().length, 1, "validator leaving should be completed");
-        vm.roll(block.number + WithdrawalQueue.unbondingPeriod());
+        vm.roll(block.number + delegation.unbondingPeriod());
         // there is no refund to claim after the unbonding period 
         uint256 controlAddressBalance = makeAddr("2").balance;
         delegation.claim();
@@ -1349,7 +1349,7 @@ contract NonLiquidDelegationTest is BaseDelegationTest {
         vm.deal(makeAddr("2"), makeAddr("2").balance + amount);
         delegation.stake{value: amount}();
         vm.stopPrank();
-        vm.roll(block.number + WithdrawalQueue.unbondingPeriod());
+        vm.roll(block.number + delegation.unbondingPeriod());
         // if staker claims which calls withdrawDeposit() after the unbonding period, pendingWithdrawals will be 0
         vm.startPrank(stakers[4-1]);
         delegation.claim();
@@ -1359,7 +1359,7 @@ contract NonLiquidDelegationTest is BaseDelegationTest {
         vm.startPrank(makeAddr("2"));
         delegation.leave(validator(2));
         assertEq(delegation.validators().length, 1, "validator leaving should be completed");
-        vm.roll(block.number + WithdrawalQueue.unbondingPeriod());
+        vm.roll(block.number + delegation.unbondingPeriod());
         // there is no refund to claim after the unbonding period 
         uint256 controlAddressBalance = makeAddr("2").balance;
         delegation.claim();
@@ -1367,6 +1367,17 @@ contract NonLiquidDelegationTest is BaseDelegationTest {
         vm.stopPrank();
         assertApproxEqAbs(withdrawnRewards1[0], withdrawnRewards2[2], 10, "withdrawn rewards mismatch");
         assertApproxEqAbs(withdrawnRewards1[1], withdrawnRewards2[3], 10, "withdrawn rewards mismatch");
+    }
+
+    function test_InstantUnstakeBeforeActivation() public {
+        vm.deal(stakers[0], stakers[0].balance + 110 ether);
+        vm.startPrank(stakers[0]);
+        delegation.stake{value: 100 ether}();
+        uint256 stakerBalance = stakers[0].balance;
+        delegation.unstake(delegation.getDelegatedAmount());
+        delegation.claim();
+        assertEq(stakers[0].balance - stakerBalance, 100 ether, "balance must increase instantly");
+        vm.stopPrank();
     }
 
     function test_UnstakeNotTooMuch() public {
@@ -1546,7 +1557,7 @@ contract NonLiquidDelegationTest is BaseDelegationTest {
         //Console.log("staker balance: %s.%s%s", stakers[i-1].balance);
         vm.stopPrank();
 
-        vm.roll(block.number + WithdrawalQueue.unbondingPeriod());
+        vm.roll(block.number + delegation.unbondingPeriod());
 
         i = 1;
         vm.startPrank(stakers[i-1]);
@@ -1665,7 +1676,7 @@ contract NonLiquidDelegationTest is BaseDelegationTest {
         //Console.log("staker balance: %s.%s%s", stakers[i-1].balance);
         vm.stopPrank();
 
-        vm.roll(block.number + WithdrawalQueue.unbondingPeriod());
+        vm.roll(block.number + delegation.unbondingPeriod());
 
         i = 1;
         vm.startPrank(stakers[i-1]);


### PR DESCRIPTION
While the funds required for depositing a validator are being collected by the delegation contract, users staking with the contract shall be able to unstake and claim without waiting for the unbonding period.