### PR TITLE
Minimize the impact of rounding errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,8 +352,7 @@ To enable the tests to interact with the Zilliqa 2.0 deposit contract, the contr
 @zilliqa/zq2/=/home/user/zq2/zilliqa/src/contracts/
 ```
 
-To execute end-to-end tests on a local network, set `consensus.staker_withdrawal_period` to 5 and
-`consensus.blocks_per_epoch` to 3 in `config_docker.toml` and run
+To execute end-to-end tests on a local network, set the funds of the first item in `consensus.genesis_accounts` to `5000000000000000000000000`, `consensus.staker_withdrawal_period` to 5 and `consensus.blocks_per_epoch` to 3 in `config_docker.toml` and run
 ```bash
 chmod +x e2e_liquid.sh && ./e2e_liquid.sh
 chmod +x e2e_non-liquid.sh && ./e2e_non-liquid.sh

--- a/e2e_liquid.sh
+++ b/e2e_liquid.sh
@@ -20,6 +20,17 @@ CONTROL_KEY_4=0xdb670cbff28f4b15297d03fafdab8f5303d68b7591bd59e31eaef215dd0f246a
 
 
 
+staker() {
+    # $1 = 2-digit index
+    # $2 = STAKER_KEY or STAKER_ADDRESS
+    STAKER_KEY=${STAKER_KEY:0:64}$1
+    STAKER_ADDRESS=$(cast wallet address $STAKER_KEY)
+    local var=$2
+    echo ${!var}
+}
+
+
+
 unbond() {
     # sleep two times as many seconds as many blocks the deposit withdrawal period
     # consists of to wait long enough even if there is a 2 second average block time
@@ -204,25 +215,92 @@ join_all() {
 
 
 
+stake_one() {
+    # $1 = 2-digit staker index
+    # $2 = amount
+    echo "############################### STAKING ##############################"
+    echo -n "🟢 staker balance: " && cast to-unit $(cast balance $(staker $1 STAKER_ADDRESS)) ether
+    echo -n "🟢 lst balance: " && cast to-unit $(cast call $(cast call $CONTRACT_ADDRESS "getLST()(address)") "balanceOf(address)(uint256)" $(staker $1 STAKER_ADDRESS) | sed 's/\[[^]]*\]//g') ether
+    echo -n "🟢 lst price: " && cast to-unit $(cast call $CONTRACT_ADDRESS "getPrice()(uint256)" | sed 's/\[[^]]*\]//g') ether
+    echo -n "🟢 commission: " && cast to-unit $(cast balance $COMMISSION_ADDRESS) ether
+    temp=$(forge script script/Stake.s.sol --broadcast --legacy --sig "run(address payable, uint256)" $CONTRACT_ADDRESS $2 --private-key $(staker $1 STAKER_KEY) 2>&1 1>/dev/null)
+    errors=$(echo $temp | grep -o -i -e "error" -e "fail" -e "revert" | wc -l)
+    if [ $errors -eq 0 ]; then
+        echo "🟢 Stake $1"
+    else
+        echo "🔴 Stake $1 $temp"
+    fi
+    echo -n "🟢 commission: " && cast to-unit $(cast balance $COMMISSION_ADDRESS) ether
+    echo -n "🟢 lst balance: " && cast to-unit $(cast call $(cast call $CONTRACT_ADDRESS "getLST()(address)") "balanceOf(address)(uint256)" $(staker $1 STAKER_ADDRESS) | sed 's/\[[^]]*\]//g') ether
+    echo -n "🟢 lst price: " && cast to-unit $(cast call $CONTRACT_ADDRESS "getPrice()(uint256)" | sed 's/\[[^]]*\]//g') ether
+    echo -n "🟢 staker balance: " && cast to-unit $(cast balance $(staker $1 STAKER_ADDRESS)) ether
+    sleep 2s
+}
+
+
+
+unstake_one() {
+    # $1 = 2-digit staker index
+    # $2 = amount
+    echo "############################### UNSTAKING ##############################"
+    echo -n "🟢 commission: " && cast to-unit $(cast balance $COMMISSION_ADDRESS) ether
+    echo -n "🟢 lst balance: " && cast to-unit $(cast call $(cast call $CONTRACT_ADDRESS "getLST()(address)") "balanceOf(address)(uint256)" $(staker $1 STAKER_ADDRESS) | sed 's/\[[^]]*\]//g') ether
+    echo -n "🟢 lst price: " && cast to-unit $(cast call $CONTRACT_ADDRESS "getPrice()(uint256)" | sed 's/\[[^]]*\]//g') ether
+    echo -n "🟢 staker balance: " && cast to-unit $(cast balance $(staker $1 STAKER_ADDRESS)) ether
+    temp=$(forge script script/Unstake.s.sol --broadcast --legacy --sig "run(address payable, uint256)" $CONTRACT_ADDRESS $2 --private-key $(staker $1 STAKER_KEY) 2>&1 1>/dev/null)
+    errors=$(echo $temp | grep -o -i -e "error" -e "fail" -e "revert" | wc -l)
+    if [ $errors -eq 0 ]; then
+        echo "🟢 Unstake $1"
+    else
+        echo "🔴 Unstake $1 $temp"
+    fi
+    echo -n "🟢 commission: " && cast to-unit $(cast balance $COMMISSION_ADDRESS) ether
+    echo -n "🟢 lst balance: " && cast to-unit $(cast call $(cast call $CONTRACT_ADDRESS "getLST()(address)") "balanceOf(address)(uint256)" $(staker $1 STAKER_ADDRESS) | sed 's/\[[^]]*\]//g') ether
+    echo -n "🟢 lst price: " && cast to-unit $(cast call $CONTRACT_ADDRESS "getPrice()(uint256)" | sed 's/\[[^]]*\]//g') ether
+    echo -n "🟢 staker balance: " && cast to-unit $(cast balance $(staker $1 STAKER_ADDRESS)) ether
+    sleep 2s
+}
+
+
+
+claim_one() {
+    # $1 = 2-digit staker index
+    echo "############################### CLAIMING ##############################"
+    echo -n "🟢 claimable: " && cast to-unit $(cast call $CONTRACT_ADDRESS "getClaimable()(uint256)" --from $(staker $1 STAKER_ADDRESS) | sed 's/\[[^]]*\]//g') ether
+    echo -n "🟢 commission: " && cast to-unit $(cast balance $COMMISSION_ADDRESS) ether
+    echo -n "🟢 lst balance: " && cast to-unit $(cast call $(cast call $CONTRACT_ADDRESS "getLST()(address)") "balanceOf(address)(uint256)" $(staker $1 STAKER_ADDRESS) | sed 's/\[[^]]*\]//g') ether
+    echo -n "🟢 lst price: " && cast to-unit $(cast call $CONTRACT_ADDRESS "getPrice()(uint256)" | sed 's/\[[^]]*\]//g') ether
+    echo -n "🟢 staker balance: " && cast to-unit $(cast balance $(staker $1 STAKER_ADDRESS)) ether
+    temp=$(forge script script/Claim.s.sol --broadcast --legacy --sig "run(address payable)" $CONTRACT_ADDRESS --private-key $(staker $1 STAKER_KEY) 2>&1 1>/dev/null)
+    errors=$(echo $temp | grep -o -i -e "error" -e "fail" -e "revert" | wc -l)
+    if [ $errors -eq 0 ]; then
+        echo "🟢 Claim $1"
+    else
+        echo "🔴 Claim $1 $temp"
+    fi
+    echo -n "🟢 claimable: " && cast to-unit $(cast call $CONTRACT_ADDRESS "getClaimable()(uint256)" --from $(staker $1 STAKER_ADDRESS) | sed 's/\[[^]]*\]//g') ether
+    echo -n "🟢 commission: " && cast to-unit $(cast balance $COMMISSION_ADDRESS) ether
+    echo -n "🟢 lst balance: " && cast to-unit $(cast call $(cast call $CONTRACT_ADDRESS "getLST()(address)") "balanceOf(address)(uint256)" $(staker $1 STAKER_ADDRESS) | sed 's/\[[^]]*\]//g') ether
+    echo -n "🟢 lst price: " && cast to-unit $(cast call $CONTRACT_ADDRESS "getPrice()(uint256)" | sed 's/\[[^]]*\]//g') ether
+    echo -n "🟢 staker balance: " && cast to-unit $(cast balance $(staker $1 STAKER_ADDRESS)) ether
+    sleep 2s
+}
+
+
+
 stake_all() {
     echo "############################### EARNING ##############################"
     sleep 10s
-    echo "############################### STAKING ##############################"
-    cast send --legacy --value 300ether --private-key 0x0000000000000000000000000000000000000000000000000000000000000002 $STAKER_ADDRESS 1>/dev/null
-    echo -n "🟢 staker balance: " && cast to-unit $(cast balance $STAKER_ADDRESS) ether
 
-    echo -n "🟢 commission: " && cast to-unit $(cast balance $COMMISSION_ADDRESS) ether
-    temp=$(forge script script/Stake.s.sol --broadcast --legacy --sig "run(address payable, uint256)" $CONTRACT_ADDRESS 200000000000000000000 --private-key $STAKER_KEY 2>&1 1>/dev/null)
-    errors=$(echo $temp | grep -o -i -e "error" -e "fail" -e "revert" | wc -l)
-    if [ $errors -eq 0 ]; then
-        echo "🟢 Stake"
-    else
-        echo "🔴 Stake $temp"
-    fi
-    echo -n "🟢 commission: " && cast to-unit $(cast balance $COMMISSION_ADDRESS) ether
-    echo -n "🟢 lst balance: " && cast to-unit $(cast call $(cast call $CONTRACT_ADDRESS "getLST()(address)") "balanceOf(address)(uint256)" $STAKER_ADDRESS | sed 's/\[[^]]*\]//g') ether
-    echo -n "🟢 lst price: " && cast to-unit $(cast call $CONTRACT_ADDRESS "getPrice()(uint256)" | sed 's/\[[^]]*\]//g') ether
-    echo -n "🟢 controller balance: " && cast to-unit $(cast balance $STAKER_ADDRESS) ether
+    cast send --legacy --value 300ether --private-key 0x0000000000000000000000000000000000000000000000000000000000000002 $(staker 01 STAKER_ADDRESS) 1>/dev/null
+    stake_one 01 200000000000000000000
+
+    cast send --legacy --value 2100ether --private-key 0x0000000000000000000000000000000000000000000000000000000000000002 $(staker 02 STAKER_ADDRESS) 1>/dev/null
+    stake_one 02 2000000000000000000000
+
+    cast send --legacy --value 20100ether --private-key 0x0000000000000000000000000000000000000000000000000000000000000002 $(staker 03 STAKER_ADDRESS) 1>/dev/null
+    stake_one 03 20000000000000000000000
+
     validators=$(cast call $CONTRACT_ADDRESS "validators()(bool[])" | grep -o "true" | wc -l)
     if [ $validators -gt 0 ]; then
         priv_key=$CONTROL_KEY_3
@@ -245,27 +323,19 @@ stake_all() {
     echo "############################### EARNING ##############################"
     sleep 10s
 
-    echo "############################### UNSTAKING ##############################"
-    temp=$(forge script script/Unstake.s.sol --broadcast --legacy --sig "run(address payable, uint256)" $CONTRACT_ADDRESS 100000000000000000000 --private-key $STAKER_KEY 2>&1 1>/dev/null)
-    errors=$(echo $temp | grep -o -i -e "error" -e "fail" -e "revert" | wc -l)
-    if [ $errors -eq 0 ]; then
-        echo "🟢 Unstake"
-    else
-        echo "🔴 Unstake $temp"
-    fi
-    echo -n "🟢 commission: " && cast to-unit $(cast balance $COMMISSION_ADDRESS) ether
-    echo -n "🟢 lst balance: " && cast to-unit $(cast call $(cast call $CONTRACT_ADDRESS "getLST()(address)") "balanceOf(address)(uint256)" $STAKER_ADDRESS | sed 's/\[[^]]*\]//g') ether
-    echo -n "🟢 lst price: " && cast to-unit $(cast call $CONTRACT_ADDRESS "getPrice()(uint256)" | sed 's/\[[^]]*\]//g') ether
-    echo -n "🟢 staker balance: " && cast to-unit $(cast balance $STAKER_ADDRESS) ether
+    unstake_one 01 100000000000000000000
+
+    unstake_one 02 1000000000000000000000
+
+    unstake_one 03 10000000000000000000000
 
     echo "############################### UNBONDING ##############################"
     unbond
 
     echo "############################### STAKING REWARDS ##############################"
     echo -n "🟢 commission: " && cast to-unit $(cast balance $COMMISSION_ADDRESS) ether
-    echo -n "🟢 lst balance: " && cast to-unit $(cast call $(cast call $CONTRACT_ADDRESS "getLST()(address)") "balanceOf(address)(uint256)" $STAKER_ADDRESS | sed 's/\[[^]]*\]//g') ether
+    echo -n "🟢 lst balance: " && cast to-unit $(cast call $(cast call $CONTRACT_ADDRESS "getLST()(address)") "balanceOf(address)(uint256)" $(staker 01 STAKER_ADDRESS) | sed 's/\[[^]]*\]//g') ether
     echo -n "🟢 lst price: " && cast to-unit $(cast call $CONTRACT_ADDRESS "getPrice()(uint256)" | sed 's/\[[^]]*\]//g') ether
-    echo -n "🟢 staker balance: " && cast to-unit $(cast balance $STAKER_ADDRESS) ether
     temp=$(forge script script/StakeRewards.s.sol --broadcast --legacy --sig "run(address payable)" $CONTRACT_ADDRESS --private-key $OWNER_KEY 2>&1 1>/dev/null)
     errors=$(echo $temp | grep -o -i -e "error" -e "fail" -e "revert" | wc -l)
     if [ $errors -eq 0 ]; then
@@ -274,25 +344,14 @@ stake_all() {
         echo "🔴 StakeRewards $temp"
     fi
     echo -n "🟢 commission: " && cast to-unit $(cast balance $COMMISSION_ADDRESS) ether
-    echo -n "🟢 lst balance: " && cast to-unit $(cast call $(cast call $CONTRACT_ADDRESS "getLST()(address)") "balanceOf(address)(uint256)" $STAKER_ADDRESS | sed 's/\[[^]]*\]//g') ether
+    echo -n "🟢 lst balance: " && cast to-unit $(cast call $(cast call $CONTRACT_ADDRESS "getLST()(address)") "balanceOf(address)(uint256)" $(staker 01 STAKER_ADDRESS) | sed 's/\[[^]]*\]//g') ether
     echo -n "🟢 lst price: " && cast to-unit $(cast call $CONTRACT_ADDRESS "getPrice()(uint256)" | sed 's/\[[^]]*\]//g') ether
-    echo -n "🟢 staker balance: " && cast to-unit $(cast balance $STAKER_ADDRESS) ether
 
-    echo "############################### CLAIMING ##############################"
-    echo -n "🟢 claimable: " && cast to-unit $(cast call $CONTRACT_ADDRESS "getClaimable()(uint256)" --from $STAKER_ADDRESS | sed 's/\[[^]]*\]//g') ether
-    temp=$(forge script script/Claim.s.sol --broadcast --legacy --sig "run(address payable)" $CONTRACT_ADDRESS --private-key $STAKER_KEY 2>&1 1>/dev/null)
-    errors=$(echo $temp | grep -o -i -e "error" -e "fail" -e "revert" | wc -l)
-    if [ $errors -eq 0 ]; then
-        echo "🟢 Claim"
-    else
-        echo "🔴 Claim $temp"
-    fi
-    echo -n "🟢 claimable: " && cast to-unit $(cast call $CONTRACT_ADDRESS "getClaimable()(uint256)" --from $STAKER_ADDRESS | sed 's/\[[^]]*\]//g') ether
+    claim_one 01
 
-    echo -n "🟢 commission: " && cast to-unit $(cast balance $COMMISSION_ADDRESS) ether
-    echo -n "🟢 lst balance: " && cast to-unit $(cast call $(cast call $CONTRACT_ADDRESS "getLST()(address)") "balanceOf(address)(uint256)" $STAKER_ADDRESS | sed 's/\[[^]]*\]//g') ether
-    echo -n "🟢 lst price: " && cast to-unit $(cast call $CONTRACT_ADDRESS "getPrice()(uint256)" | sed 's/\[[^]]*\]//g') ether
-    echo -n "🟢 staker balance: " && cast to-unit $(cast balance $STAKER_ADDRESS) ether
+    claim_one 02
+
+    claim_one 03
 
     echo "############################### EARNING ##############################"
     sleep 10s
@@ -366,20 +425,11 @@ unstake_all() {
     echo -n "🟢 total rewards: " && cast to-unit $(cast call $CONTRACT_ADDRESS "getRewards()(uint256)" | sed 's/\[[^]]*\]//g') ether
     echo -n "🟢 lst price: " && cast to-unit $(cast call $CONTRACT_ADDRESS "getPrice()(uint256)" | sed 's/\[[^]]*\]//g') ether
 
-    echo "############################### UNSTAKING ##############################"
-    echo -n "🟢 commission: " && cast to-unit $(cast balance $COMMISSION_ADDRESS) ether
-    echo -n "🟢 lst balance: " && cast to-unit $(cast call $(cast call $CONTRACT_ADDRESS "getLST()(address)") "balanceOf(address)(uint256)" $STAKER_ADDRESS | sed 's/\[[^]]*\]//g') ether
-    echo -n "🟢 staker balance: " && cast to-unit $(cast balance $STAKER_ADDRESS) ether
-    temp=$(forge script script/Unstake.s.sol --broadcast --legacy --sig "run(address payable, uint256)" $CONTRACT_ADDRESS $(cast call $(cast call $CONTRACT_ADDRESS "getLST()(address)") "balanceOf(address)(uint256)" $STAKER_ADDRESS) --private-key $STAKER_KEY 2>&1 1>/dev/null)
-    errors=$(echo $temp | grep -o -i -e "error" -e "fail" -e "revert" | wc -l)
-    if [ $errors -eq 0 ]; then
-        echo "🟢 Unstake"
-    else
-        echo "🔴 Unstake $temp"
-    fi
-    echo -n "🟢 commission: " && cast to-unit $(cast balance $COMMISSION_ADDRESS) ether
-    echo -n "🟢 lst balance: " && cast to-unit $(cast call $(cast call $CONTRACT_ADDRESS "getLST()(address)") "balanceOf(address)(uint256)" $STAKER_ADDRESS | sed 's/\[[^]]*\]//g') ether
-    echo -n "🟢 staker balance: " && cast to-unit $(cast balance $STAKER_ADDRESS) ether
+    unstake_one 01 $(cast call $(cast call $CONTRACT_ADDRESS "getLST()(address)") "balanceOf(address)(uint256)" $(staker 01 STAKER_ADDRESS))
+
+    unstake_one 02 $(cast call $(cast call $CONTRACT_ADDRESS "getLST()(address)") "balanceOf(address)(uint256)" $(staker 02 STAKER_ADDRESS))
+
+    unstake_one 03 $(cast call $(cast call $CONTRACT_ADDRESS "getLST()(address)") "balanceOf(address)(uint256)" $(staker 03 STAKER_ADDRESS))
 
     echo "############################### UNBONDING ##############################"
     unbond
@@ -387,22 +437,11 @@ unstake_all() {
     echo -n "🟢 total rewards: " && cast to-unit $(cast call $CONTRACT_ADDRESS "getRewards()(uint256)" | sed 's/\[[^]]*\]//g') ether
     echo -n "🟢 lst price: " && cast to-unit $(cast call $CONTRACT_ADDRESS "getPrice()(uint256)" | sed 's/\[[^]]*\]//g') ether
 
-    echo "############################### CLAIMING ##############################"
-    echo -n "🟢 commission: " && cast to-unit $(cast balance $COMMISSION_ADDRESS) ether
-    echo -n "🟢 lst balance: " && cast to-unit $(cast call $(cast call $CONTRACT_ADDRESS "getLST()(address)") "balanceOf(address)(uint256)" $STAKER_ADDRESS | sed 's/\[[^]]*\]//g') ether
-    echo -n "🟢 staker balance: " && cast to-unit $(cast balance $STAKER_ADDRESS) ether
-    echo -n "🟢 claimable: " && cast to-unit $(cast call $CONTRACT_ADDRESS "getClaimable()(uint256)" --from $STAKER_ADDRESS | sed 's/\[[^]]*\]//g') ether
-    temp=$(forge script script/Claim.s.sol --broadcast --legacy --sig "run(address payable)" $CONTRACT_ADDRESS --private-key $STAKER_KEY 2>&1 1>/dev/null)
-    errors=$(echo $temp | grep -o -i -e "error" -e "fail" -e "revert" | wc -l)
-    if [ $errors -eq 0 ]; then
-        echo "🟢 Claim"
-    else
-        echo "🔴 Claim $temp"
-    fi
-    echo -n "🟢 claimable: " && cast to-unit $(cast call $CONTRACT_ADDRESS "getClaimable()(uint256)" --from $STAKER_ADDRESS | sed 's/\[[^]]*\]//g') ether
-    echo -n "🟢 commission: " && cast to-unit $(cast balance $COMMISSION_ADDRESS) ether
-    echo -n "🟢 staker balance: " && cast to-unit $(cast balance $STAKER_ADDRESS) ether
-    echo -n "🟢 lst balance: " && cast to-unit $(cast call $(cast call $CONTRACT_ADDRESS "getLST()(address)") "balanceOf(address)(uint256)" $STAKER_ADDRESS | sed 's/\[[^]]*\]//g') ether
+    claim_one 01
+
+    claim_one 02
+
+    claim_one 03
 }
 
 

--- a/e2e_non-liquid.sh
+++ b/e2e_non-liquid.sh
@@ -502,34 +502,23 @@ report() {
 
 join_all # all validators join the pool
 stake_all # all users stake, withdraw rewards, unstake and claim part of it
-echo -n "🟪" && cast call $CONTRACT_ADDRESS "totalRoundingErrors()(uint256)"
 leave_all # all validators leave and withdraw rewards
-echo -n "🟪🟪" && cast call $CONTRACT_ADDRESS "totalRoundingErrors()(uint256)"
 unstake_all # all users unstake everything and withdraw rewards
-echo -n "🟪🟪🟪" && cast call $CONTRACT_ADDRESS "totalRoundingErrors()(uint256)"
 report # print the status
 echo "1️⃣ 1️⃣ 1️⃣ 1️⃣ 1️⃣ 1️⃣ 1️⃣ 1️⃣ 1️⃣ 1️⃣ 1️⃣ 1️⃣ 1️⃣ 1️⃣ 1️⃣ 1️⃣"
-echo -n "🟪🟪🟪🟪" && cast call $CONTRACT_ADDRESS "totalRoundingErrors()(uint256)"
 
 sleep 5s
 
 stake_all
-echo -n "🟪" && cast call $CONTRACT_ADDRESS "totalRoundingErrors()(uint256)"
 unstake_all
-echo -n "🟪🟪🟪" && cast call $CONTRACT_ADDRESS "totalRoundingErrors()(uint256)"
 report
 echo "2️⃣ 2️⃣ 2️⃣ 2️⃣ 2️⃣ 2️⃣ 2️⃣ 2️⃣ 2️⃣ 2️⃣ 2️⃣ 2️⃣ 2️⃣ 2️⃣ 2️⃣ 2️⃣"
-echo -n "🟪🟪🟪🟪" && cast call $CONTRACT_ADDRESS "totalRoundingErrors()(uint256)"
 
 sleep 5s
 
 join_all
 stake_all
-echo -n "🟪" && cast call $CONTRACT_ADDRESS "totalRoundingErrors()(uint256)"
 leave_all
-echo -n "🟪🟪" && cast call $CONTRACT_ADDRESS "totalRoundingErrors()(uint256)"
 unstake_all
-echo -n "🟪🟪🟪" && cast call $CONTRACT_ADDRESS "totalRoundingErrors()(uint256)"
 report
 echo "3️⃣ 3️⃣ 3️⃣ 3️⃣ 3️⃣ 3️⃣ 3️⃣ 3️⃣ 3️⃣ 3️⃣ 3️⃣ 3️⃣ 3️⃣ 3️⃣ 3️⃣ 3️⃣"
-echo -n "🟪🟪🟪🟪" && cast call $CONTRACT_ADDRESS "totalRoundingErrors()(uint256)"

--- a/e2e_non-liquid.sh
+++ b/e2e_non-liquid.sh
@@ -502,23 +502,34 @@ report() {
 
 join_all # all validators join the pool
 stake_all # all users stake, withdraw rewards, unstake and claim part of it
+echo -n "🟪" && cast call $CONTRACT_ADDRESS "totalRoundingErrors()(uint256)"
 leave_all # all validators leave and withdraw rewards
+echo -n "🟪🟪" && cast call $CONTRACT_ADDRESS "totalRoundingErrors()(uint256)"
 unstake_all # all users unstake everything and withdraw rewards
+echo -n "🟪🟪🟪" && cast call $CONTRACT_ADDRESS "totalRoundingErrors()(uint256)"
 report # print the status
 echo "1️⃣ 1️⃣ 1️⃣ 1️⃣ 1️⃣ 1️⃣ 1️⃣ 1️⃣ 1️⃣ 1️⃣ 1️⃣ 1️⃣ 1️⃣ 1️⃣ 1️⃣ 1️⃣"
+echo -n "🟪🟪🟪🟪" && cast call $CONTRACT_ADDRESS "totalRoundingErrors()(uint256)"
 
 sleep 5s
 
 stake_all
+echo -n "🟪" && cast call $CONTRACT_ADDRESS "totalRoundingErrors()(uint256)"
 unstake_all
+echo -n "🟪🟪🟪" && cast call $CONTRACT_ADDRESS "totalRoundingErrors()(uint256)"
 report
 echo "2️⃣ 2️⃣ 2️⃣ 2️⃣ 2️⃣ 2️⃣ 2️⃣ 2️⃣ 2️⃣ 2️⃣ 2️⃣ 2️⃣ 2️⃣ 2️⃣ 2️⃣ 2️⃣"
+echo -n "🟪🟪🟪🟪" && cast call $CONTRACT_ADDRESS "totalRoundingErrors()(uint256)"
 
 sleep 5s
 
 join_all
 stake_all
+echo -n "🟪" && cast call $CONTRACT_ADDRESS "totalRoundingErrors()(uint256)"
 leave_all
+echo -n "🟪🟪" && cast call $CONTRACT_ADDRESS "totalRoundingErrors()(uint256)"
 unstake_all
+echo -n "🟪🟪🟪" && cast call $CONTRACT_ADDRESS "totalRoundingErrors()(uint256)"
 report
 echo "3️⃣ 3️⃣ 3️⃣ 3️⃣ 3️⃣ 3️⃣ 3️⃣ 3️⃣ 3️⃣ 3️⃣ 3️⃣ 3️⃣ 3️⃣ 3️⃣ 3️⃣ 3️⃣"
+echo -n "🟪🟪🟪🟪" && cast call $CONTRACT_ADDRESS "totalRoundingErrors()(uint256)"

--- a/src/BaseDelegation.sol
+++ b/src/BaseDelegation.sol
@@ -211,7 +211,7 @@ abstract contract BaseDelegation is IDelegation, PausableUpgradeable, Ownable2St
     /**
     * @dev The current version of all upgradeable contracts in the repository.
     */
-    uint64 internal immutable VERSION = encodeVersion(0, 5, 0);
+    uint64 internal immutable VERSION = encodeVersion(0, 5, 1);
 
     /**
     * @dev Return the contracts' version.

--- a/src/NonLiquidDelegation.sol
+++ b/src/NonLiquidDelegation.sol
@@ -80,6 +80,8 @@ contract NonLiquidDelegation is IDelegation, BaseDelegation, INonLiquidDelegatio
         mapping(address => uint256) taxedSinceLastStaking;
         int256 immutableRewards;
         mapping(address => address) newAddress;
+        mapping(address => uint256) roundingErrors;
+        uint256 totalRoundingErrors;
     }
 
     // keccak256(abi.encode(uint256(keccak256("zilliqa.storage.NonLiquidDelegation")) - 1)) & ~bytes32(uint256(0xff))
@@ -319,6 +321,13 @@ contract NonLiquidDelegation is IDelegation, BaseDelegation, INonLiquidDelegatio
         return resultInTotal - resultInTotal * getCommissionNumerator() / DENOMINATOR + $.availableTaxedRewards[_msgSender()];
     }
 
+    /* this breaks the invariant that getRewards() is not decreasing over time and causes underflows
+    function getRewards() public view override returns(uint256 total) {
+        total = super.getRewards(); 
+        NonLiquidDelegationStorage storage $ = _getNonLiquidDelegationStorage();
+        total -= $.totalRoundingErrors / 1 ether;
+    }*/
+
     /**
     * @dev Return the total amount of taxed rewards the caller is eligible to withdraw.
     */
@@ -394,6 +403,15 @@ contract NonLiquidDelegation is IDelegation, BaseDelegation, INonLiquidDelegatio
     }
 
     /**
+    * @dev Returns the total amount of rewards in `wei * 10**18` that was not paid out due to
+    * rounding errors.
+    */
+    function totalRoundingErrors() public view returns(uint256) {
+        NonLiquidDelegationStorage storage $ = _getNonLiquidDelegationStorage();
+        return $.totalRoundingErrors;
+    }
+ 
+    /**
     * @dev Make the requested `amount` of taxed rewards available to the caller for staking or
     * withdrawing by traversing the {Staking} history in `1 + additionalSteps`.
     * If `amount == type(uint256).max` then all rewards were requested. In that case return the
@@ -402,14 +420,19 @@ contract NonLiquidDelegation is IDelegation, BaseDelegation, INonLiquidDelegatio
     */
     function _useRewards(uint256 amount, uint64 additionalSteps) internal whenNotPaused returns(uint256, uint256) {
         NonLiquidDelegationStorage storage $ = _getNonLiquidDelegationStorage();
+        uint256 oldRoundingError = $.roundingErrors[_msgSender()];
         (
             uint256 resultInTotal,
             uint256 resultAfterLastStaking,
             uint64 posInStakingIndices,
             uint64 nextStakingIndex,
+            uint256 roundingError
         ) = additionalSteps == type(uint64).max ?
             _rewards() :
             _rewards(additionalSteps);
+        $.roundingErrors[_msgSender()] = roundingError;
+        $.totalRoundingErrors -= oldRoundingError;
+        $.totalRoundingErrors += roundingError;
         // the caller has not delegated any stake yet
         if (nextStakingIndex == 0)
             return (0, 0);
@@ -463,6 +486,7 @@ contract NonLiquidDelegation is IDelegation, BaseDelegation, INonLiquidDelegatio
         uint64 firstStakingIndex;
         uint256 amount;
         uint256 total;
+        roundingError = $.roundingErrors[_msgSender()];
         for (
             posInStakingIndices = $.firstStakingIndex[_msgSender()];
             posInStakingIndices < $.stakingIndices[_msgSender()].length;
@@ -489,14 +513,19 @@ contract NonLiquidDelegation is IDelegation, BaseDelegation, INonLiquidDelegatio
                 }
                 total = $.stakings[nextStakingIndex].total;
                 nextStakingIndex++;
-                if (nextStakingIndex - firstStakingIndex > additionalSteps)
+                if (nextStakingIndex - firstStakingIndex > additionalSteps) {
+                    if (getRewards() >= resultInTotal + roundingError / 1 ether) {
+                        resultInTotal += roundingError / 1 ether;
+                        roundingError -= 1 ether * (roundingError / 1 ether);
+                    }
                     return (
-                        resultInTotal + roundingError / 1 ether,
+                        resultInTotal,
                         resultAfterLastStaking, 
                         posInStakingIndices, 
                         nextStakingIndex, 
-                        roundingError - 1 ether * (roundingError / 1 ether)
+                        roundingError
                     );
+                }
             }    
         }
 
@@ -517,8 +546,10 @@ contract NonLiquidDelegation is IDelegation, BaseDelegation, INonLiquidDelegatio
         // existed during the current call of the function so that we can continue from there
         if (posInStakingIndices > 0)
             posInStakingIndices--;
-        resultInTotal += roundingError / 1 ether;
-        roundingError -= 1 ether * (roundingError / 1 ether);
+        if (getRewards() >= resultInTotal + roundingError / 1 ether) {
+            resultInTotal += roundingError / 1 ether;
+            roundingError -= 1 ether * (roundingError / 1 ether);
+        }
     }
 
     /**

--- a/src/NonLiquidDelegation.sol
+++ b/src/NonLiquidDelegation.sol
@@ -80,6 +80,8 @@ contract NonLiquidDelegation is IDelegation, BaseDelegation, INonLiquidDelegatio
         mapping(address => uint256) taxedSinceLastStaking;
         int256 immutableRewards;
         mapping(address => address) newAddress;
+mapping(address => uint256) roundingErrors;
+uint256 totalRoundingErrors;
     }
 
     // keccak256(abi.encode(uint256(keccak256("zilliqa.storage.NonLiquidDelegation")) - 1)) & ~bytes32(uint256(0xff))
@@ -314,7 +316,9 @@ contract NonLiquidDelegation is IDelegation, BaseDelegation, INonLiquidDelegatio
     */
     function rewards(uint64 additionalSteps) public view returns(uint256) {
         NonLiquidDelegationStorage storage $ = _getNonLiquidDelegationStorage();
-        (uint256 resultInTotal, , , ) = _rewards(additionalSteps);
+//TODO: replace
+//        (uint256 resultInTotal, , , ) = _rewards(additionalSteps);
+        (uint256 resultInTotal, , , , , ) = _rewards(additionalSteps);
         resultInTotal -= $.taxedSinceLastStaking[_msgSender()];
         return resultInTotal - resultInTotal * getCommissionNumerator() / DENOMINATOR + $.availableTaxedRewards[_msgSender()];
     }
@@ -324,7 +328,9 @@ contract NonLiquidDelegation is IDelegation, BaseDelegation, INonLiquidDelegatio
     */
     function rewards() public view returns(uint256) {
         NonLiquidDelegationStorage storage $ = _getNonLiquidDelegationStorage();
-        (uint256 resultInTotal, , , ) = _rewards();
+//TODO: replace
+//        (uint256 resultInTotal, , , ) = _rewards();
+        (uint256 resultInTotal, , , , , ) = _rewards();
         resultInTotal -= $.taxedSinceLastStaking[_msgSender()];
         return resultInTotal - resultInTotal * getCommissionNumerator() / DENOMINATOR + $.availableTaxedRewards[_msgSender()];
     }
@@ -393,6 +399,14 @@ contract NonLiquidDelegation is IDelegation, BaseDelegation, INonLiquidDelegatio
         emit Staked(_msgSender(), amount, "");
     }
 
+//TODO: natspec comment
+function totalRoundingErrors() public view returns(uint256) {
+    NonLiquidDelegationStorage storage $ = _getNonLiquidDelegationStorage();
+    return $.totalRoundingErrors;
+}
+
+//TODO: remove
+event Test(string,uint);
     /**
     * @dev Make the requested `amount` of taxed rewards available to the caller for staking or
     * withdrawing by traversing the {Staking} history in `1 + additionalSteps`.
@@ -402,14 +416,22 @@ contract NonLiquidDelegation is IDelegation, BaseDelegation, INonLiquidDelegatio
     */
     function _useRewards(uint256 amount, uint64 additionalSteps) internal whenNotPaused returns(uint256, uint256) {
         NonLiquidDelegationStorage storage $ = _getNonLiquidDelegationStorage();
+// # emit Test("$.totalRoundingErrors", $.totalRoundingErrors);
+// # emit Test("$.roundingErrors[_msgSender()]", $.roundingErrors[_msgSender()]);
+// # $.totalRoundingErrors -= $.roundingErrors[_msgSender()];
         (
             uint256 resultInTotal,
             uint256 resultAfterLastStaking,
             uint64 posInStakingIndices,
-            uint64 nextStakingIndex
+            uint64 nextStakingIndex,
+uint256 roundingError,
+uint256 totalRoundingErrors
         ) = additionalSteps == type(uint64).max ?
             _rewards() :
             _rewards(additionalSteps);
+// # $.roundingErrors[_msgSender()] += roundingError;
+// # $.totalRoundingErrors += roundingError;
+// # //$.totalRoundingErrors = totalRoundingErrors;
         // the caller has not delegated any stake yet
         if (nextStakingIndex == 0)
             return (0, 0);
@@ -442,7 +464,9 @@ contract NonLiquidDelegation is IDelegation, BaseDelegation, INonLiquidDelegatio
         uint256 resultInTotal,
         uint256 resultAfterLastStaking,
         uint64 posInStakingIndices,
-        uint64 nextStakingIndex
+        uint64 nextStakingIndex,
+uint256 roundingError,
+uint256 totalRoundingErrors
     ) {
         return _rewards(type(uint64).max);
     }
@@ -455,12 +479,17 @@ contract NonLiquidDelegation is IDelegation, BaseDelegation, INonLiquidDelegatio
         uint256 resultInTotal,
         uint256 resultAfterLastStaking,
         uint64 posInStakingIndices,
-        uint64 nextStakingIndex
+        uint64 nextStakingIndex,
+uint256 roundingError,
+uint256 totalRoundingErrors
     ) {
         NonLiquidDelegationStorage storage $ = _getNonLiquidDelegationStorage();
         uint64 firstStakingIndex;
         uint256 amount;
         uint256 total;
+// # totalRoundingErrors = $.totalRoundingErrors;
+// # //TODO: enable the below line
+// # //roundingError = $.roundingErrors[_msgSender()];
         for (
             posInStakingIndices = $.firstStakingIndex[_msgSender()];
             posInStakingIndices < $.stakingIndices[_msgSender()].length;
@@ -481,10 +510,24 @@ contract NonLiquidDelegation is IDelegation, BaseDelegation, INonLiquidDelegatio
             ) {
                 if (total > 0)
                     resultInTotal += $.stakings[nextStakingIndex].rewards * amount / total;
+if (total > 0) {
+roundingError +=
+    1 ether * $.stakings[nextStakingIndex].rewards * amount / total -
+    1 ether * ($.stakings[nextStakingIndex].rewards * amount / total);
+// # // totalRoundingErrors = $.totalRoundingErrors + roundingError - $.roundingErrors[_msgSender()];
+}
                 total = $.stakings[nextStakingIndex].total;
                 nextStakingIndex++;
                 if (nextStakingIndex - firstStakingIndex > additionalSteps)
-                    return (resultInTotal, resultAfterLastStaking, posInStakingIndices, nextStakingIndex);
+// # //TODO: remove                    return (resultInTotal, resultAfterLastStaking, posInStakingIndices, nextStakingIndex);
+                    return (
+                        resultInTotal + roundingError / 1 ether,
+                        resultAfterLastStaking, 
+                        posInStakingIndices, 
+                        nextStakingIndex, 
+                        roundingError - 1 ether * (roundingError / 1 ether),
+                        totalRoundingErrors 
+                    );
             }    
         }
 
@@ -493,6 +536,12 @@ contract NonLiquidDelegation is IDelegation, BaseDelegation, INonLiquidDelegatio
             // the last step is to add the rewards accrued since the last staking
             if (total > 0) {
                 resultAfterLastStaking = (int256(getRewards()) - $.immutableRewards).toUint256() * amount / total;
+// # //TODO: replace the above line with
+// # //      resultAfterLastStaking = (int256(getRewards()) - totalRoundingErrors / 1 ether - $.immutableRewards).toUint256() * amount / total;
+roundingError +=
+    1 ether * (int256(getRewards()) - $.immutableRewards).toUint256() * amount / total -
+    1 ether * ((int256(getRewards()) - $.immutableRewards).toUint256() * amount / total);
+// # // totalRoundingErrors = $.totalRoundingErrors + roundingError - $.roundingErrors[_msgSender()];
                 resultInTotal += resultAfterLastStaking;
             }
         }
@@ -502,6 +551,9 @@ contract NonLiquidDelegation is IDelegation, BaseDelegation, INonLiquidDelegatio
         // existed during the current call of the function so that we can continue from there
         if (posInStakingIndices > 0)
             posInStakingIndices--;
+resultInTotal += roundingError / 1 ether;
+roundingError -= 1 ether * (roundingError / 1 ether);
+// # // totalRoundingErrors = $.totalRoundingErrors + roundingError - $.roundingErrors[_msgSender()];
     }
 
     /**

--- a/test/NonLiquidDelegation.t.sol
+++ b/test/NonLiquidDelegation.t.sol
@@ -2049,6 +2049,7 @@ contract NonLiquidDelegationTest is BaseDelegationTest {
             Console.log("round %s of %s", i, numOfRounds);
             assertEq(delegation.getStake(), delegation.getDelegatedTotal(), "getStake does not match getDelegatedTotal");
             assertEq(totalWithdrawnZil + delegation.totalPendingWithdrawals(), totalUnstakedZil, "owned does not match owed");
+            assertLt(delegation.totalRoundingErrors(), numOfUsers * 1 ether, "rounding errors out of bounds");
         }
         uint256 outstandingRewards;
         for (uint256 i = 0; i < users.length; i++) {


### PR DESCRIPTION
When calculating non-liquid staking rewards, divisions will lead to rounding errors bounded by the number of steps. The loss of rewards shall be reduced to less than 1 wei per call to `_rewards()` or, ideally, to less than 1 wei per delegator. 