### PR TITLE
Allow splitting the stake between validator nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,16 @@ cast send --legacy --value 5000000ether --private-key $PRIVATE_KEY \
 0xb14832a866a49ddf8a3104f8ee379d29c136f29aeb8fccec9d7fb17180b99e8ed29bee2ada5ce390cb704bc6fd7f5ce814f914498376c4b8bc14841a57ae22279769ec8614e2673ba7f36edc5a4bf5733aa9d70af626279ee2b2cde939b4bd8a
 ```
 
+If you want to deposit only a certain amount from the delegation contract's available stake, run the following command with the amount (e.g. 10 million ZIL) specified as the last argument:
+```bash
+cast send --legacy --value 5000000ether --private-key $PRIVATE_KEY \
+0x7a0b7e6d24ede78260c9ddbd98e828b0e11a8ea2 "depositFromPool(bytes,bytes,bytes,uint256)" \
+0x92fbe50544dce63cfdcc88301d7412f0edea024c91ae5d6a04c7cd3819edfc1b9d75d9121080af12e00f054d221f876c \
+0x002408011220d5ed74b09dcbe84d3b32a56c01ab721cf82809848b6604535212a219d35c412f \
+0xb14832a866a49ddf8a3104f8ee379d29c136f29aeb8fccec9d7fb17180b99e8ed29bee2ada5ce390cb704bc6fd7f5ce814f914498376c4b8bc14841a57ae22279769ec8614e2673ba7f36edc5a4bf5733aa9d70af626279ee2b2cde939b4bd8a \
+10000000000000000000000000
+```
+
 Note that the reward address registered for the validator node will be the address of the delegation contract (the proxy contract to be more precise), but the deposit will not take effect and the node will not start to earn rewards until the epoch after next.
 
 
@@ -512,6 +522,7 @@ If the execution reverts, you can look up the error based on the first 4 bytes o
 0xa8ca83c9   StakerAlreadyExists(address)
 0x30e667d2   IncompatibleVersion(uint64)
 0x8579befe   ZeroAddressNotAllowed()
+0xa0753f46   InsufficientAvailableStake(uint256,uint256)
 ```
 
 

--- a/src/LiquidDelegation.sol
+++ b/src/LiquidDelegation.sol
@@ -106,7 +106,27 @@ contract LiquidDelegation is IDelegation, BaseDelegation {
         _depositAndAddToPool(
             blsPubKey,
             peerId,
-            signature
+            signature,
+            0
+        );
+    } 
+
+    /// @inheritdoc BaseDelegation
+    function depositFromPool(
+        bytes calldata blsPubKey,
+        bytes calldata peerId,
+        bytes calldata signature,
+        uint256 amount
+    ) public override payable onlyOwner {
+        if (msg.value > 0)
+            _stake(msg.value, _msgSender());
+        // the total stake must not be increased before the price is determined
+        _increaseStake(msg.value);
+        _depositAndAddToPool(
+            blsPubKey,
+            peerId,
+            signature,
+            amount
         );
     } 
 

--- a/src/NonLiquidDelegation.sol
+++ b/src/NonLiquidDelegation.sol
@@ -146,7 +146,28 @@ contract NonLiquidDelegation is IDelegation, BaseDelegation {
         _depositAndAddToPool(
             blsPubKey,
             peerId,
-            signature
+            signature,
+            0
+        );
+        // the owner's deposit must also be recorded as staking otherwise
+        // the owner would not benefit from the rewards accrued by the deposit
+        if (msg.value > 0)
+            _appendToHistory(int256(msg.value), _msgSender());
+    }
+
+    /// @inheritdoc BaseDelegation
+    function depositFromPool(
+        bytes calldata blsPubKey,
+        bytes calldata peerId,
+        bytes calldata signature,
+        uint256 amount
+    ) public payable override onlyOwner {
+        _increaseStake(msg.value);
+        _depositAndAddToPool(
+            blsPubKey,
+            peerId,
+            signature,
+            amount
         );
         // the owner's deposit must also be recorded as staking otherwise
         // the owner would not benefit from the rewards accrued by the deposit


### PR DESCRIPTION
When calling `depositfromPool` the pool owner should be able to specify how much of the stake available for the deposit should be used. If there is enough stake available, the owner will be able to deposit multiple nodes.